### PR TITLE
Flock Compute Base

### DIFF
--- a/code/datums/abilities/flock/flockmind.dm
+++ b/code/datums/abilities/flock/flockmind.dm
@@ -3,8 +3,29 @@
 ///////////////////////
 
 /datum/abilityHolder/flockmind
+	tabName = "Flockmind"
+	usesPoints = 1
+	points = 0 //total compute - used compute
+	var/tC = 0 //total compute
+	regenRate = 0
 	topBarRendered = 1
 	rendered = 1
+	notEnoughPointsMessage = "<span class='alert'>Insufficient available compute resources.</span>"
+
+/datum/abilityHolder/flockmind/proc/updateCompute()
+	var/mob/living/intangible/flock/flockmind/F = owner
+	if(!F?.flock)
+		return //someone made a flockmind without a flock, or gave this ability holder to something else.
+	src.tC = F.flock.total_compute()
+	var/uC = F.flock.used_compute()
+	src.points = src.tC - uC
+
+/datum/abilityHolder/flockmind/onAbilityStat()
+	..()
+	.= list()
+	.["Compute:"] = "[round(src.points)]/[round(src.tC)]"
+	//.["Total Compute:"] = round(F.flock?.total_compute())
+	return
 
 /atom/movable/screen/ability/topBar/flockmind
 	tens_offset_x = 19
@@ -120,6 +141,9 @@
 
 /datum/targetable/flockmindAbility/partitionMind/cast(atom/target)
 	if(..())
+		return 1
+	if(!holder.pointCheck(100))
+		boutput(holder,"<span class='alert'>You need more compute to partition yourself</span>")
 		return 1
 	var/mob/living/intangible/flock/flockmind/F = holder.owner
 	if(F)

--- a/code/datums/abilities/flock/flockmind.dm
+++ b/code/datums/abilities/flock/flockmind.dm
@@ -6,7 +6,7 @@
 	tabName = "Flockmind"
 	usesPoints = 1
 	points = 0 //total compute - used compute
-	var/tC = 0 //total compute
+	var/totalCompute = 0
 	regenRate = 0
 	topBarRendered = 1
 	rendered = 1
@@ -16,14 +16,14 @@
 	var/mob/living/intangible/flock/flockmind/F = owner
 	if(!F?.flock)
 		return //someone made a flockmind without a flock, or gave this ability holder to something else.
-	src.tC = F.flock.total_compute()
-	var/uC = F.flock.used_compute()
-	src.points = src.tC - uC
+	src.totalCompute = F.flock.total_compute()
+	var/usedCompute = F.flock.used_compute()
+	src.points = src.totalCompute - usedCompute
 
 /datum/abilityHolder/flockmind/onAbilityStat()
 	..()
 	.= list()
-	.["Compute:"] = "[round(src.points)]/[round(src.tC)]"
+	.["Compute:"] = "[round(src.points)]/[round(src.totalCompute)]"
 	//.["Total Compute:"] = round(F.flock?.total_compute())
 	return
 

--- a/code/datums/flock/flock.dm
+++ b/code/datums/flock/flock.dm
@@ -186,6 +186,8 @@
 			res += abs(tmp)
 	return res
 
+/datum/flock/proc/can_afford_compute(var/cost)
+	return (cost <= src.total_compute() - src.used_compute())
 
 /datum/flock/proc/registerFlockmind(var/mob/living/intangible/flock/flockmind/F)
 	if(!F)

--- a/code/datums/flock/flock.dm
+++ b/code/datums/flock/flock.dm
@@ -90,19 +90,19 @@
 
 	// DESCRIBE TRACES
 	var/list/tracelist = list()
-	for(var/mob/living/intangible/flock/trace/T in src.traces)
+	for(var/mob/living/intangible/flock/trace/T as anything in src.traces)
 		tracelist += list(T.describe_state())
 	state["partitions"] = tracelist
 
 	// DESCRIBE DRONES
 	var/list/dronelist = list()
-	for(var/mob/living/critter/flock/drone/F in src.units)
+	for(var/mob/living/critter/flock/drone/F as anything in src.units)
 		dronelist += list(F.describe_state())
 	state["drones"] = dronelist
 
 	// DESCRIBE STRUCTURES
 	var/list/structureList = list()
-	for(var/obj/flock_structure/structure in src.structures)
+	for(var/obj/flock_structure/structure as anything in src.structures)
 		structureList += list(structure.describe_state())
 	state["structures"] = structureList
 
@@ -137,7 +137,7 @@
 /datum/flock/proc/total_health_percentage()
 	var/hp = 0
 	var/max_hp = 0
-	for(var/mob/living/critter/flock/F in src.units)
+	for(var/mob/living/critter/flock/F as anything in src.units)
 		F.count_healths()
 		hp += F.health
 		max_hp += F.max_health
@@ -148,19 +148,19 @@
 
 /datum/flock/proc/total_resources()
 	. = 0
-	for(var/mob/living/critter/flock/F in src.units)
+	for(var/mob/living/critter/flock/F as anything in src.units)
 		. += F.resources
 
 
 /datum/flock/proc/total_compute()
 	. = 0
 	var/comp_provided = 0
-	for(var/mob/living/critter/flock/F in src.units)
+	for(var/mob/living/critter/flock/F as anything in src.units)
 		comp_provided = F.compute_provided()
 		if(comp_provided>0)
 			. += comp_provided
 
-	for(var/obj/flock_structure/S in src.structures)
+	for(var/obj/flock_structure/S as anything in src.structures)
 		comp_provided = S.compute_provided()
 		if(comp_provided>0)
 			. += comp_provided
@@ -169,18 +169,18 @@
 /datum/flock/proc/used_compute()
 	. = 0
 	var/comp_provided = 0
-	for(var/mob/living/critter/flock/F in src.units)
+	for(var/mob/living/critter/flock/F as anything in src.units)
 		comp_provided = F.compute_provided()
 		if(comp_provided<0)
 			. += abs(comp_provided)
 
-	for(var/obj/flock_structure/S in src.structures)
+	for(var/obj/flock_structure/S as anything in src.structures)
 		comp_provided = S.compute_provided()
 		if(comp_provided<0)
 			. += abs(comp_provided)
 
 	//not strictly necessary, but maybe future traces can provide compute in some way or cost more when doing stuff?
-	for(var/mob/living/intangible/flock/trace/T in src.traces)
+	for(var/mob/living/intangible/flock/trace/T as anything in src.traces)
 		comp_provided = T.compute_provided()
 		if(comp_provided<0)
 			. += abs(comp_provided)

--- a/code/datums/flock/flock.dm
+++ b/code/datums/flock/flock.dm
@@ -147,44 +147,43 @@
 		return 0
 
 /datum/flock/proc/total_resources()
-	var/res = 0
+	. = 0
 	for(var/mob/living/critter/flock/F in src.units)
-		res += F.resources
-	return res
+		. += F.resources
+
 
 /datum/flock/proc/total_compute()
-	var/res = 0
-	var/tmp = 0
+	. = 0
+	var/comp_provided = 0
 	for(var/mob/living/critter/flock/F in src.units)
-		tmp = F.compute_provided()
-		if(tmp>0)
-			res += tmp
+		comp_provided = F.compute_provided()
+		if(comp_provided>0)
+			. += comp_provided
 
 	for(var/obj/flock_structure/S in src.structures)
-		tmp = S.compute_provided()
-		if(tmp>0)
-			res += tmp
-	return res
+		comp_provided = S.compute_provided()
+		if(comp_provided>0)
+			. += comp_provided
+
 
 /datum/flock/proc/used_compute()
-	var/res = 0
-	var/tmp = 0
+	. = 0
+	var/comp_provided = 0
 	for(var/mob/living/critter/flock/F in src.units)
-		tmp = F.compute_provided()
-		if(tmp<0)
-			res += abs(tmp)
+		comp_provided = F.compute_provided()
+		if(comp_provided<0)
+			. += abs(comp_provided)
 
 	for(var/obj/flock_structure/S in src.structures)
-		tmp = S.compute_provided()
-		if(tmp<0)
-			res += abs(tmp)
+		comp_provided = S.compute_provided()
+		if(comp_provided<0)
+			. += abs(comp_provided)
 
 	//not strictly necissary, but maybe future traces can provide compute in some way or cost more when doing stuff?
 	for(var/mob/living/intangible/flock/trace/T in src.traces)
-		tmp = T.compute_provided()
-		if(tmp<0)
-			res += abs(tmp)
-	return res
+		comp_provided = T.compute_provided()
+		if(comp_provided<0)
+			. += abs(comp_provided)
 
 /datum/flock/proc/can_afford_compute(var/cost)
 	return (cost <= src.total_compute() - src.used_compute())
@@ -318,15 +317,15 @@
 		aH.updateCompute()
 // STRUCTURES
 
-/datum/flock/proc/registerStructure(var/atom/movable/D)
-	if(isflockstructure(D))
-		src.structures |= D
+/datum/flock/proc/registerStructure(var/atom/movable/S)
+	if(isflockstructure(S))
+		src.structures |= S
 		var/datum/abilityHolder/flockmind/aH = src.flockmind.abilityHolder
 		aH.updateCompute()
 
-/datum/flock/proc/removeStructure(var/atom/movable/D)
-	if(isflockstructure(D))
-		src.structures -= D
+/datum/flock/proc/removeStructure(var/atom/movable/S)
+	if(isflockstructure(S))
+		src.structures -= S
 		var/datum/abilityHolder/flockmind/aH = src.flockmind.abilityHolder
 		aH.updateCompute()
 

--- a/code/datums/flock/flocktilegroup.dm
+++ b/code/datums/flock/flocktilegroup.dm
@@ -3,9 +3,7 @@
 	var/list/members = list() //what tiles are a part of the group
 	var/list/connected = list() //what structures are connected
 	var/size = 0 //how many tiles in there
-	var/powerbalance = 0 //how much power is in the grid, in the form of a net balance
-	var/poweruse = 0 //how much is being used
-	var/powergen = 0 //how much is being produced
+
 	var/datum/flock/flock = null
 	var/debugid = 0 //debuggin id
 
@@ -24,7 +22,7 @@
 	..() //linter machine go ANGRY
 
 /datum/flock_tile_group/proc/process()
-	calcpower()
+	..()
 
 /datum/flock_tile_group/proc/addtile(var/turf/simulated/floor/feather/f)
 	members |= f
@@ -40,13 +38,4 @@
 /datum/flock_tile_group/proc/removestructure(var/obj/flock_structure/f)
 	connected -= f
 
-/datum/flock_tile_group/proc/calcpower()
-	src.powergen = 0
-	src.poweruse = 0
-	for(var/obj/flock_structure/f in connected)
-		if(f.poweruse < 0)
-			src.powergen += abs(f.poweruse)
-		else if(f.poweruse > 0)
-			src.poweruse += f.poweruse
 
-	src.powerbalance = src.powergen - src.poweruse

--- a/code/datums/flock/flocktilegroup.dm
+++ b/code/datums/flock/flocktilegroup.dm
@@ -22,7 +22,7 @@
 	..() //linter machine go ANGRY
 
 /datum/flock_tile_group/proc/process()
-	..()
+	. = 0
 
 /datum/flock_tile_group/proc/addtile(var/turf/simulated/floor/feather/f)
 	members |= f

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -8,6 +8,7 @@
 	can_grab = 1
 	can_disarm = 1
 	can_help = 1
+	compute = 10
 	death_text = "%src% clatters into a heap of fragments."
 	pet_text = list("taps", "pats", "drums on", "ruffles", "touches", "pokes", "prods")
 	custom_brain_type = /obj/item/organ/brain/flockdrone

--- a/code/mob/living/critter/flockcritter_parent.dm
+++ b/code/mob/living/critter/flockcritter_parent.dm
@@ -19,6 +19,8 @@
 	var/health_brute_vuln = 1.2 // glass
 	var/health_burn = 1
 	var/health_burn_vuln = 0.2 // don't burn very well at all
+	//base compute provided
+	var/compute = 0
 	// if we're extinguishing ourselves don't extinguish ourselves repeatedly
 	var/extinguishing = 0
 	// FLOCK-SPECIFIC STUFF
@@ -65,6 +67,10 @@
 	else
 		state["area"] = "???"
 	return state
+
+//compute - override if behaviour is weird
+/mob/living/critter/flock/proc/compute_provided()
+	return src.compute
 
 // can we afford the resource cost of a thing?
 /mob/living/critter/flock/proc/can_afford(var/resources)

--- a/code/mob/living/intangible/flock/flockmind.dm
+++ b/code/mob/living/intangible/flock/flockmind.dm
@@ -7,7 +7,6 @@
 	desc = "The collective machine consciousness of a bunch of glass peacock things."
 	icon = 'icons/misc/featherzone.dmi'
 	icon_state = "flockmind"
-
 	var/started = 0
 	var/last_time // when i say per second I MEAN PER SECOND DAMMIT
 
@@ -33,6 +32,7 @@
     <br><span class='bold'>ID:</span> [src.real_name]
     <br><span class='bold'>Flock:</span> [src.flock ? src.flock.name : "none, somehow"]
     <br><span class='bold'>Resources:</span> [src.flock.total_resources()]
+	<br><span class='bold'>Total Compute:</span> [src.flock.total_compute()]
     <br><span class='bold'>System Integrity:</span> [round(src.flock.total_health_percentage()*100)]%
     <br><span class='bold'>Cognition:</span> COMPUTATIONAL NEXUS
     <br>###=-</span></span>"}
@@ -57,7 +57,7 @@
 /mob/living/intangible/flock/flockmind/Life(datum/controller/process/mobs/parent)
 	if (..(parent))
 		return 1
-	if (src.started && src.flock && src.flock.units && src.flock.units.len <= 0)
+	if (src.started && src.flock && src.flock.total_compute() <= 0)
 		src.death() // get rekt
 
 /mob/living/intangible/flock/flockmind/proc/spawnEgg()

--- a/code/mob/living/intangible/flock/flocktrace.dm
+++ b/code/mob/living/intangible/flock/flocktrace.dm
@@ -9,6 +9,7 @@
 	desc = "The representation of a partition of the will of the flockmind."
 	icon = 'icons/misc/featherzone.dmi'
 	icon_state = "flocktrace"
+	compute = -100 //it is expensive to run more threads
 
 /mob/living/intangible/flock/trace/New(atom/loc, datum/flock/F)
 	..()
@@ -65,7 +66,9 @@
 /mob/living/intangible/flock/trace/Life(datum/controller/process/mobs/parent)
 	if (..(parent))
 		return 1
-	if (src.flock && src.flock.units && src.flock.units.len <= 0)
+	var/datum/abilityHolder/flockmind/aH = src.abilityHolder
+	aH.updateCompute()
+	if (src.flock && src.flock.total_compute() <= 0)
 		boutput(src, "<span class='alert'>There are no more drones left in the flock to compute your consciousness!</span>")
 		src.death() // get rekt
 

--- a/code/mob/living/intangible/flock/flocktrace.dm
+++ b/code/mob/living/intangible/flock/flocktrace.dm
@@ -68,8 +68,8 @@
 		return 1
 	var/datum/abilityHolder/flockmind/aH = src.abilityHolder
 	aH.updateCompute()
-	if (src.flock && src.flock.total_compute() <= 0)
-		boutput(src, "<span class='alert'>There are no more drones left in the flock to compute your consciousness!</span>")
+	if (src.flock && src.flock.total_compute() <= src.flock.used_compute())
+		boutput(src, "<span class='alert'>There are insufficient drones left in the flock to compute your consciousness!</span>")
 		src.death() // get rekt
 
 /mob/living/intangible/flock/trace/death(gibbed)

--- a/code/mob/living/intangible/flockmob_parent.dm
+++ b/code/mob/living/intangible/flockmob_parent.dm
@@ -13,6 +13,7 @@
 	blinded = 0
 	anchored = 1
 	use_stamina = 0//no puff tomfuckery
+	var/compute = 0
 	var/datum/flock/flock = null
 	var/wear_id = null // to prevent runtimes from AIs tracking down radio signals
 
@@ -196,3 +197,7 @@
 /mob/living/intangible/flock/proc/createstructure(var/T, var/resources = 0)
 	//todo check for flocktile underneath flockmind cheers
 	new /obj/flock_structure/ghost(src.loc, T, src.flock, resources)
+
+//compute - override if behaviour is weird
+/mob/living/intangible/flock/proc/compute_provided()
+	return src.compute

--- a/code/obj/flock/structure/collector.dm
+++ b/code/obj/flock/structure/collector.dm
@@ -17,7 +17,6 @@
 	// drones can pass through this, might change this later, as balance point
 	passthrough = TRUE
 
-	poweruse = 0
 	usesgroups = TRUE
 	icon_state = "collector"
 
@@ -26,7 +25,7 @@
 
 /obj/flock_structure/collector/building_specific_info()
 	return {"<span class='bold'>Connections:</span> Currently Connected to [length(connectedto)] tile[length(connectedto) == 1 ? "" : "s"].
-	<br><span class='bold'>Power generation:</span> Currently generating [abs(poweruse)]."}
+	<br><span class='bold'>Compute generation:</span> Currently generating [src.compute_provided()]."}
 
 /obj/flock_structure/collector/process()
 	..()
@@ -35,7 +34,8 @@
 		icon_state = "collectoron"
 	else
 		icon_state = "collector"
-	src.poweruse = ((length(connectedto) * 5) / -1) //(5 power per tile)
+	//TODO: Rebalance this when we do the proper compute strucutres and computers pass
+	src.compute = (length(connectedto) * 5) //(5 power per tile)
 
 /obj/flock_structure/collector/disposing()
 	for(var/turf/simulated/floor/feather/flocktile as anything in connectedto)

--- a/code/obj/flock/structure/egg.dm
+++ b/code/obj/flock/structure/egg.dm
@@ -11,6 +11,7 @@
 	flock_id = "Second-Stage Assembler"
 	build_time = 6
 	health = 30 // fragile little thing
+	compute = 1 //just to make sure that you don't die seconds before a drone hatches
 	var/decal_made = 0 // for splashing stuff on throw
 
 /obj/flock_structure/egg/New(var/atom/location, var/datum/flock/F=null)

--- a/code/obj/flock/structure/flock_structure_parent.dm
+++ b/code/obj/flock/structure/flock_structure_parent.dm
@@ -20,8 +20,6 @@
 	var/compute = 0
 	/// can flockdrones pass through this akin to a grille? need to set USE_CANPASS to make this work however
 	var/passthrough = FALSE
-	/// does this use(/how much) power? (negatives mean it makes power)
-	var/poweruse = 0
 	/// not everything needs a group so dont check for everysingle god damn structure
 	var/usesgroups = FALSE
 	/// what group are we connected to?

--- a/code/obj/flock/structure/flock_structure_parent.dm
+++ b/code/obj/flock/structure/flock_structure_parent.dm
@@ -16,6 +16,8 @@
 	/// very flame-retardant
 	var/fireVuln = 0.2
 	var/datum/flock/flock = null
+	//base compute provided
+	var/compute = 0
 	/// can flockdrones pass through this akin to a grille? need to set USE_CANPASS to make this work however
 	var/passthrough = FALSE
 	/// does this use(/how much) power? (negatives mean it makes power)
@@ -34,7 +36,7 @@
 	processing_items |= src
 	if(F)
 		src.flock = F
-		src.flock.structures += src
+		src.flock.registerStructure(src)
 	if(usesgroups && istype(get_turf(src), /turf/simulated/floor/feather))
 		var/turf/simulated/floor/feather/f = get_turf(src)
 		grouptile = f
@@ -44,7 +46,7 @@
 /obj/flock_structure/disposing()
 	processing_items -= src
 	if (flock)
-		flock.structures -= src
+		flock.removeStructure(src)
 	flock = null
 	group = null
 	..()
@@ -74,6 +76,10 @@
 		return special_desc
 	else
 		return null // give the standard description
+
+//override this if compute is conditional or something
+/obj/flock_structure/proc/compute_provided()
+	return src.compute
 
 /obj/flock_structure/proc/building_specific_info()
 	return ""

--- a/code/obj/flock/structure/rift.dm
+++ b/code/obj/flock/structure/rift.dm
@@ -11,6 +11,7 @@
 	flock_id = "Entry Rift"
 	build_time = 10
 	health = 200 // stronk little thing
+	compute = 5
 	var/decal_made = 0 // for splashing stuff on throw
 	var/list/eject = list()
 	var/mainflock = null // for when a flockmind is spawning the little shits(read:drones) get assigned to it

--- a/code/obj/flock/structure/sentinel.dm
+++ b/code/obj/flock/structure/sentinel.dm
@@ -22,6 +22,8 @@
 
 	usesgroups = TRUE
 
+	compute = -20 //targetting consumes compute
+
 	// debug amount scale up if needed.
 	poweruse = 20
 

--- a/code/obj/flock/structure/sentinel.dm
+++ b/code/obj/flock/structure/sentinel.dm
@@ -21,11 +21,8 @@
 	passthrough = TRUE
 
 	usesgroups = TRUE
-
-	compute = -20 //targetting consumes compute
-
-	// debug amount scale up if needed.
-	poweruse = 20
+	var/online_compute_cost = 20
+	compute = 0 //targetting consumes compute
 
 	var/obj/effect/flock_sentinelrays/rays = null
 
@@ -48,10 +45,13 @@
 
 	if(!src.group)//if it dont exist it off
 		powered = FALSE
-	else if(src.group.powerbalance >= 0)//if it has atleast 0 or more free power, the poweruse is already calculated in the group
+		src.compute = 0
+	else if(src.flock.can_afford_compute(online_compute_cost))//if it has atleast 0 or more free compute, the poweruse is already calculated in the group
 		powered = TRUE
+		src.compute = -online_compute_cost
 	else//if there isnt enough juice
 		powered = FALSE
+		src.compute = 0
 
 	if(powered == 1)
 		switch(charge_status)

--- a/code/turf/turf_flock.dm
+++ b/code/turf/turf_flock.dm
@@ -172,8 +172,6 @@
 	else if(length(groups_found) > 1) //if there is more then one, then join the largest (add merging functionality here later)
 		for(var/datum/flock_tile_group/oldgroup in groups_found)
 			if(oldgroup == largestgroup) continue
-			largestgroup.powergen += oldgroup.powergen
-			largestgroup.poweruse += oldgroup.poweruse
 			for(var/turf/simulated/floor/feather/F in oldgroup.members)
 				F.group = largestgroup
 				largestgroup.addtile(F)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Establishes the base of the compute resource, adding a couple of utility functions and a UI element to the flockmind/flocktrace ability holder.

Also added the check that ensures flocktraces die when there is insufficient compute power.

Collectors also provisionally generate compute based on the number of tiles they were connected to. This should probably be changed, but makes a handy test case until we decide how it should change.

Sentinels now check to see if there is 20 available compute, and are active if this is the case. Previously this was a check on power.

Notably the code for tilegroups seems to have been exclusively used for determining power generation/consumption in a localised way. I've taken the power part out but left the tile grouping code in. Maybe we can use it for something in future or remove it at a later date.

## Why's this needed? 
Setting up for the midgame 

