### PR TITLE
Restrict Flockmind rift placement

### DIFF
--- a/code/datums/abilities/flock/flockmind.dm
+++ b/code/datums/abilities/flock/flockmind.dm
@@ -57,10 +57,38 @@
 
 /datum/targetable/flockmindAbility/spawnEgg/cast(atom/target)
 	if(..())
-		return 1
+		return
 	var/mob/living/intangible/flock/flockmind/F = holder.owner
-	if(F)
-		F.spawnEgg()
+
+	var/turf/T = get_turf(F)
+
+	if (istype(T, /turf/space/) || istype(T.loc, /area/station/solar) || istype(T.loc, /area/station/mining/magnet))
+		boutput(F, "<span class='alert'>Space and exposed areas are unsuitable for rift placement!</span>")
+		return
+
+	if (!isadmin(F))
+		if(IS_ARRIVALS(T.loc))
+			boutput(F, "<spawn class='alert'>Your rift can't be placed inside arrivals!</span>")
+			return
+
+		if (!istype(T.loc, /area/station/))
+			boutput(F, "<spawn class='alert'>Your rift needs to be placed on the [station_or_ship()]!</span>")
+			return
+
+		if (istype(T, /turf/unsimulated/))
+			boutput(F, "<span class='alert'>This kind of tile cannot support rift placement.</span>")
+			return
+
+		if (T.density)
+			boutput(F, "<span class='alert'>Your rift cannot be placed inside a wall!</span>")
+			return
+
+		for (var/atom/O in T.contents)
+			if (O.density)
+				boutput(F, "<span class='alert'>That tile is blocked by [O].</span>")
+				return
+
+	F.spawnEgg()
 
 /////////////////////////////////////////
 

--- a/code/datums/abilities/flock/flockmind.dm
+++ b/code/datums/abilities/flock/flockmind.dm
@@ -57,36 +57,37 @@
 
 /datum/targetable/flockmindAbility/spawnEgg/cast(atom/target)
 	if(..())
-		return
+		return TRUE
+
 	var/mob/living/intangible/flock/flockmind/F = holder.owner
 
 	var/turf/T = get_turf(F)
 
 	if (istype(T, /turf/space/) || istype(T.loc, /area/station/solar) || istype(T.loc, /area/station/mining/magnet))
 		boutput(F, "<span class='alert'>Space and exposed areas are unsuitable for rift placement!</span>")
-		return
+		return TRUE
 
 	if (!isadmin(F))
 		if(IS_ARRIVALS(T.loc))
 			boutput(F, "<spawn class='alert'>Your rift can't be placed inside arrivals!</span>")
-			return
+			return TRUE
 
 		if (!istype(T.loc, /area/station/))
 			boutput(F, "<spawn class='alert'>Your rift needs to be placed on the [station_or_ship()]!</span>")
-			return
+			return TRUE
 
 		if (istype(T, /turf/unsimulated/))
 			boutput(F, "<span class='alert'>This kind of tile cannot support rift placement.</span>")
-			return
+			return TRUE
 
 		if (T.density)
 			boutput(F, "<span class='alert'>Your rift cannot be placed inside a wall!</span>")
-			return
+			return TRUE
 
 		for (var/atom/O in T.contents)
 			if (O.density)
 				boutput(F, "<span class='alert'>That tile is blocked by [O].</span>")
-				return
+				return TRUE
 
 	F.spawnEgg()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR restricts placement of the initial Flockmind rift. The conditions that the initial blob nucleus placement has are used, along with solar panel and mining magnet areas to prevent rift spawned things from being flung out into space. There may be a few cases on maps where stuff could still be flung out into space, but this should help prevent most of it I think.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Flockmind rift placement isn't restricted right now.

Fixes #52.