### PR TITLE
Prevent creating tealprints on tiles that have something with density

### DIFF
--- a/code/datums/abilities/flock/flockmind.dm
+++ b/code/datums/abilities/flock/flockmind.dm
@@ -351,7 +351,7 @@
 		return 1
 	for (var/atom/O in T.contents)
 		if (O.density && !isflock(O))
-			boutput(holder.owner, "<span class='alert'>A tealprint cannot be scheduled with [O] on the same tile!</span>")
+			boutput(holder.owner, "<span class='alert'>That tile has something that blocks tealprint creation!</span>")
 			return 1
 	//todo: replace with FANCY tgui/chui window with WHEELS and ICONS and stuff!
 	var/structurewanted = tgui_input_list(holder.owner, "Select which structure you would like to create", "Tealprint selection", list("Collector", "Sentinel"))

--- a/code/datums/abilities/flock/flockmind.dm
+++ b/code/datums/abilities/flock/flockmind.dm
@@ -343,9 +343,16 @@
 	if(!istype(T, /turf/simulated/floor/feather))
 		boutput(holder.owner, "<span class='alert'>You aren't above a flocktile.</span>")//todo maybe make this flock themed?
 		return 1
+	if(locate(/obj/flock_structure/ghost) in T)
+		boutput(holder.owner, "<span class='alert'>A tealprint has already been scheduled here!</span>")
+		return 1
 	if(locate(/obj/flock_structure) in T)
 		boutput(holder.owner, "<span class='alert'>There is already a flock structure on this flocktile!</span>")
 		return 1
+	for (var/atom/O in T.contents)
+		if (O.density && !isflock(O))
+			boutput(holder.owner, "<span class='alert'>A tealprint cannot be scheduled with [O] on the same tile!</span>")
+			return 1
 	//todo: replace with FANCY tgui/chui window with WHEELS and ICONS and stuff!
 	var/structurewanted = tgui_input_list(holder.owner, "Select which structure you would like to create", "Tealprint selection", list("Collector", "Sentinel"))
 	switch(structurewanted)


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR prevents creating tealprints on tiles that have something with density, excluding Flockdrones since they can move through fully constructed tealprint structures.

It also adds a different message for if there's a tealprint scheduled on a tile versus a finished tealprint structure when trying to schedule a tealprint.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It doesn't make sense that you can schedule a tealprint on a tile containing something with density.