### PR TITLE
Prevent Flockdrones and Flockbits from being moved by conveyors and drivers

### DIFF
--- a/code/WorkInProgress/recycling/conveyor.dm
+++ b/code/WorkInProgress/recycling/conveyor.dm
@@ -106,6 +106,8 @@
 		return
 	if(istype(A, /obj/critter) && A:flying)		//They are flying above it, ok.
 		return
+	if(isflock(A))
+		return
 	var/movedir = dir	// base movement dir
 	if(divert && dir == divdir)	// update if diverter present
 		movedir = divert

--- a/code/obj/machinery/launcherloader.dm
+++ b/code/obj/machinery/launcherloader.dm
@@ -48,7 +48,7 @@
 		playsound(src, "sound/effects/pump.ogg",50, 1)
 		SPAWN(0.3 SECONDS)
 			for(var/atom/movable/AM in src.loc)
-				if(AM.anchored || AM == src || isobserver(AM) || isintangible(AM)) continue
+				if(AM.anchored || AM == src || isobserver(AM) || isintangible(AM) || isflock(AM)) continue
 				if(trash && AM.delivery_destination != "Disposals")
 					AM.delivery_destination = "Disposals"
 				step(AM,src.dir)
@@ -82,14 +82,14 @@
 		if(!operating && !driver_operating)
 			var/drive = 0
 			for(var/atom/movable/M in src.loc)
-				if(M == src || M.anchored || isobserver(M) || isintangible(M)) continue
+				if(M == src || M.anchored || isobserver(M) || isintangible(M) || isflock(M)) continue
 				drive = 1
 				break
 			if(drive) activate()
 
 	Crossed(atom/movable/A)
 		..()
-		if (istype(A, /mob/dead) || isintangible(A) || iswraith(A)) return
+		if (istype(A, /mob/dead) || isintangible(A) || iswraith(A) || isflock(A)) return
 		return_if_overlay_or_effect(A)
 		activate()
 
@@ -128,7 +128,7 @@
 
 	proc/get_next_dir()
 		for(var/atom/movable/AM in src.loc)
-			if(AM.anchored || AM == src || isobserver(AM) || isintangible(AM)) continue
+			if(AM.anchored || AM == src || isobserver(AM) || isintangible(AM) || isflock(AM)) continue
 			if(AM.delivery_destination)
 				if(destinations.Find(AM.delivery_destination))
 					return destinations[AM.delivery_destination]
@@ -153,7 +153,7 @@
 
 		SPAWN(0.3 SECONDS)
 			for(var/atom/movable/AM2 in src.loc)
-				if(AM2.anchored || AM2 == src || isobserver(AM2) || isintangible(AM2)) continue
+				if(AM2.anchored || AM2 == src || isobserver(AM2) || isintangible(AM2) || isflock(AM2)) continue
 				step(AM2,src.dir)
 
 			driver = (locate(/obj/machinery/mass_driver) in get_step(src,src.dir))
@@ -177,14 +177,14 @@
 		if(!operating && !driver_operating)
 			var/drive = 0
 			for(var/atom/movable/M in src.loc)
-				if(M == src || M.anchored || isobserver(M) || isintangible(M)) continue
+				if(M == src || M.anchored || isobserver(M) || isintangible(M) || isflock(M)) continue
 				drive = 1
 				break
 			if(drive) activate()
 
 	Crossed(atom/movable/A)
 		..()
-		if (istype(A, /mob/dead) || isintangible(A) || iswraith(A)) return
+		if (istype(A, /mob/dead) || isintangible(A) || iswraith(A) || isflock(A)) return
 
 		if (!trigger_when_no_match)
 			var/atom/movable/AM = A

--- a/code/obj/machinery/mass_driver.dm
+++ b/code/obj/machinery/mass_driver.dm
@@ -19,7 +19,7 @@
 	var/O_limit
 	var/atom/target = get_edge_target_turf(src, src.dir)
 	for(var/atom/movable/O in src.loc)
-		if(O.anchored || isobserver(O) || isintangible(O)) continue
+		if(O.anchored || isobserver(O) || isintangible(O) || isflock(O)) continue
 		O_limit++
 		if(O_limit >= 20)
 			for(var/mob/M in hearers(src, null))


### PR DESCRIPTION
[FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just makes it so that Flockdrones and Flockbits can't be moved by conveyor belts and mass driver type pushers.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It doesn't make sense considering Flockdrones and Flockbits are floating. 

It also wouldn't be good to lose them if they move onto these objects considering how valuable they can be.