### PR TITLE
Makes flock using announcement computers come out garbled

### DIFF
--- a/code/obj/machinery/computer/announcement.dm
+++ b/code/obj/machinery/computer/announcement.dm
@@ -147,11 +147,16 @@
 		logTheThing("say", user, null, "as [ID.registered] ([ID.assignment]) created a command report: [message]")
 		logTheThing("diary", user, null, "as [ID.registered] ([ID.assignment]) created a command report: [message]", "say")
 
+		var/msg_sound = src.sound_to_play
 		if(ishuman(user))
 			var/mob/living/carbon/human/H = user
 			message = process_accents(H, message) //Slurred announcements? YES!
+		if (isflock(user))
+			var/mob/living/critter/flock/flock_creature = user
+			message = radioGarbleText(message, flock_creature?.flock.snoop_clarity)
+			msg_sound = "sound/misc/flockmind/flockmind_caw.ogg"
 
-		command_announcement(message, "[A.name] Announcement by [ID.registered] ([ID.assignment])", sound_to_play)
+		command_announcement(message, "[A.name] Announcement by [ID.registered] ([ID.assignment])", msg_sound)
 		last_announcement = world.timeofday
 		message = ""
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Flock could previously make plain english announcements, now they can't. Also the announcement sound is replaced with a flock spooky.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Flocktraces are no longer able to announce "Relay is sus ඞ"