### PR TITLE
Update name tags for living Flock

### DIFF
--- a/code/mob/living/critter/flock/flockbit.dm
+++ b/code/mob/living/critter/flock/flockbit.dm
@@ -21,6 +21,7 @@
 
 	src.name = "[pick_string("flockmind.txt", "flockbit_name_adj")] [pick_string("flockmind.txt", "flockbit_name_noun")]"
 	src.real_name = "[pick(consonants_upper)].[rand(10,99)].[rand(10,99)]"
+	src.update_name_tag()
 
 /mob/living/critter/flock/bit/special_desc(dist, mob/user)
 	if(isflock(user))

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -49,6 +49,7 @@
 
 	src.name = "[pick_string("flockmind.txt", "flockdrone_name_adj")] [pick_string("flockmind.txt", "flockdrone_name_noun")]"
 	src.real_name = "[pick(consonants_lower)][pick(vowels_lower)].[pick(consonants_lower)][pick(vowels_lower)].[pick(consonants_lower)][pick(vowels_lower)]"
+	src.update_name_tag()
 
 	if(src.dormant) // we'be been flagged as dormant in the map editor or something
 		src.dormantize()

--- a/code/mob/living/intangible/flock/flockmind.dm
+++ b/code/mob/living/intangible/flock/flockmind.dm
@@ -23,6 +23,7 @@
 	src.flock = new /datum/flock()
 	src.real_name = "Flockmind [src.flock.name]"
 	src.name = src.real_name
+	src.update_name_tag()
 	src.flock.registerFlockmind(src)
 	src.flock.showAnnotations(src)
 	src.addAbility(/datum/targetable/flockmindAbility/controlPanel)

--- a/code/mob/living/intangible/flock/flocktrace.dm
+++ b/code/mob/living/intangible/flock/flocktrace.dm
@@ -4,7 +4,7 @@
 // Unlike the flockmind, when player drones exit their corporeal body to jump into another one,
 // they're tiny little flickers of thought.
 /mob/living/intangible/flock/trace
-	name = "weird radio ghost bird"
+	name = "Flocktrace"
 	real_name = "Flocktrace"
 	desc = "The representation of a partition of the will of the flockmind."
 	icon = 'icons/misc/featherzone.dmi'
@@ -19,6 +19,8 @@
 	src.abilityHolder = new /datum/abilityHolder/flockmind(src)
 
 	src.real_name = "[pick(consonants_upper)][pick(vowels_lower)].[pick(vowels_lower)]"
+	src.name = src.real_name
+	src.update_name_tag()
 
 	if(istype(F))
 		src.flock = F


### PR DESCRIPTION
[FEATURE][BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just updates name tags for all living Flock creatures.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
They previously didn't have their name tags updated after their names were set. 

This will allow you to hold alt to view the names of Flocktraces, and the Flockmind's name. 

It also fixes Flockdrones and Flockbits having different alt-viewed names (weird glowy thing and floaty gewgaw) than their right-click names.