### PR TITLE
Fix depositing resources to a tealprint when you have none

### DIFF
--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -789,7 +789,10 @@
 					else
 						actions.start(new/datum/action/bar/flock_repair(F), user)
 			if(/obj/flock_structure/ghost)
-				actions.start(new /datum/action/bar/flock_deposit(target), user)
+				if (user.resources == 0)
+					boutput(user, "<span class='alert'>No resources available for construction.</span>")
+				else
+					actions.start(new /datum/action/bar/flock_deposit(target), user)
 
 /datum/limb/flock_converter/help(mob/target, var/mob/living/critter/flock/drone/user)
 	if(!target || !user)

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -789,7 +789,7 @@
 					else
 						actions.start(new/datum/action/bar/flock_repair(F), user)
 			if(/obj/flock_structure/ghost)
-				if (user.resources == 0)
+				if (user.resources <= 0)
 					boutput(user, "<span class='alert'>No resources available for construction.</span>")
 				else
 					actions.start(new /datum/action/bar/flock_deposit(target), user)


### PR DESCRIPTION
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR prevents you from attempting to deposit resources to a tealprint when controlling a Flockdrone and you have none.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix, fixes #14.