### PR TITLE
Fix Flockdrone possession showing wrong intent on HUD

### DIFF
--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -117,6 +117,7 @@
 	pilot.set_loc(src)
 	controller = pilot
 	src.client?.color = null // stop being all fucked up and weird aaaagh
+	src.hud?.update_intent()
 	boutput(src, "<span class='flocksay'><b>\[SYSTEM: Control of drone [src.real_name] established.\]</b></span>")
 
 /mob/living/critter/flock/drone/proc/release_control()


### PR DESCRIPTION
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes a bug where when possessing a Flockdrone, it would show on the HUD your intent being help, when it was not.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix, fixes #16.