### PR TITLE
Fixed multiple flockdrones butchering the same corpse

### DIFF
--- a/code/datums/controllers/action_controls.dm
+++ b/code/datums/controllers/action_controls.dm
@@ -1530,16 +1530,23 @@ var/datum/action_controller/actions
 			interrupt(INTERRUPT_ALWAYS)
 			return
 
+	onInterrupt()
+		..()
+		if (target?.butcherer == owner)
+			target.butcherer = null
+
 	onStart()
 		..()
-		if(get_dist(owner, target) > 1 || target == null || owner == null)
+		if(get_dist(owner, target) > 1 || target == null || owner == null || target.butcherer)
 			interrupt(INTERRUPT_ALWAYS)
 			return
+		target.butcherer = owner
 		for(var/mob/O in AIviewers(owner))
 			O.show_message("<span class='alert'><B>[owner] begins to butcher [target].</B></span>", 1)
 
 	onEnd()
 		..()
+		target?.butcherer = null
 		if(owner && target)
 			target.butcher(owner)
 			for(var/mob/O in AIviewers(owner))

--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -58,6 +58,8 @@
 	// moved up from critter/small_animal
 	var/butcherable = 0
 	var/butcher_time = 1.2 SECONDS
+	/// The mob who is butchering this critter
+	var/mob/butcherer = null
 	var/meat_type = /obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat
 	var/name_the_meat = 0
 	var/skinresult = /obj/item/material_piece/cloth/leather //YEP

--- a/code/mob/living/critter/ai/flock/flocktasks.dm
+++ b/code/mob/living/critter/ai/flock/flocktasks.dm
@@ -765,7 +765,7 @@ butcher
 /datum/aiTask/sequence/goalbased/butcher/get_targets()
 	. = list()
 	for(var/mob/living/critter/flock/drone/F in view(max_dist, holder.owner))
-		if(F == holder.owner)
+		if(F == holder.owner || F.butcherer)
 			continue
 		if(isdead(F))
 			. += F


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL] [AI]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #46 by adding a reference on critter to the currently butchering mob.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
3 flockdrones all standing around butchering the same corpse is inefficient