### PR TITLE
Add Flock protection component

### DIFF
--- a/code/datums/flock/flockprotection.dm
+++ b/code/datums/flock/flockprotection.dm
@@ -43,5 +43,3 @@
 		if (!flockdrone.flock.isEnemy(attacker))
 			flock_speak(flockdrone, "Damage sighted on [source], [pick_string("flockmind.txt", "flockdrone_enemy")] [attacker]", flockdrone.flock)
 			flockdrone.flock.updateEnemy(attacker)
-
-			return

--- a/code/datums/flock/flockprotection.dm
+++ b/code/datums/flock/flockprotection.dm
@@ -1,0 +1,60 @@
+/datum/component/flock_protection
+	var/flockdrones_can_hit
+	var/report_hand_attack
+	var/report_obj_attack
+
+	var/attack_message_on_cd = FALSE
+	var/attack_message_cd = 20 SECONDS
+
+/datum/component/flock_protection/Initialize(flockdrones_can_hit, report_hand_attack, report_obj_attack)
+	src.flockdrones_can_hit = flockdrones_can_hit
+	src.report_hand_attack = report_hand_attack
+	src.report_obj_attack = report_obj_attack
+
+/datum/component/flock_protection/RegisterWithParent()
+	RegisterSignal(parent, COMSIG_ATTACKHAND, .proc/handle_attackhand)
+	RegisterSignal(parent, COMSIG_ATTACKBY, .proc/handle_attackby)
+
+/datum/component/flock_protection/proc/handle_attackhand(source, mob/user as mob)
+	if (user.a_intent != INTENT_HARM)
+		return
+
+	if (istype(user, /mob/living/critter/flock/drone) && !flockdrones_can_hit)
+		boutput(user, "<span class='alert'>The grip tool refuses to harm this, jamming briefly.</span>")
+		return TRUE
+
+	if (!istype(user, /mob/living/critter/flock/drone) && report_hand_attack)
+		src.attempt_report_attack(source, user)
+
+/datum/component/flock_protection/proc/handle_attackby(source, obj/item/W as obj, mob/user as mob)
+	if (istype(user, /mob/living/critter/flock/drone) && !flockdrones_can_hit)
+		boutput(user, "<span class='alert'>The grip tool refuses to allow damage to this, jamming briefly.</span>")
+		return TRUE
+
+	if (!istype(user, /mob/living/critter/flock/drone) && report_obj_attack)
+		src.attempt_report_attack(source, user)
+
+/datum/component/flock_protection/proc/attempt_report_attack(source, mob/attacker)
+	var/list/nearby_flockdrones = list()
+	for (var/mob/living/critter/flock/drone/flockdrone in view(7, source))
+		if (!isdead(flockdrone) && flockdrone.is_npc && flockdrone.flock)
+			nearby_flockdrones.Add(flockdrone)
+
+	if (length(nearby_flockdrones))
+		var/mob/living/critter/flock/drone/flockdrone = pick(nearby_flockdrones)
+
+		if (!flockdrone.flock.isEnemy(attacker))
+			if (!attack_message_on_cd)
+				attack_message_on_cd = TRUE
+				SPAWN(attack_message_cd) attack_message_on_cd = FALSE
+
+			flock_speak(flockdrone, "Damage sighted on [source], [pick_string("flockmind.txt", "flockdrone_enemy")] [attacker]", flockdrone.flock)
+			flockdrone.flock.updateEnemy(attacker)
+
+			return
+
+		if (!attack_message_on_cd)
+			attack_message_on_cd = TRUE
+			SPAWN(attack_message_cd) attack_message_on_cd = FALSE
+
+			flock_speak(flockdrone, "[source] being attacked", flockdrone.flock)

--- a/code/datums/flock/flockprotection.dm
+++ b/code/datums/flock/flockprotection.dm
@@ -3,9 +3,6 @@
 	var/report_hand_attack
 	var/report_obj_attack
 
-	var/attack_message_on_cd = FALSE
-	var/attack_message_cd = 20 SECONDS
-
 /datum/component/flock_protection/Initialize(flockdrones_can_hit, report_hand_attack, report_obj_attack)
 	src.flockdrones_can_hit = flockdrones_can_hit
 	src.report_hand_attack = report_hand_attack
@@ -44,17 +41,7 @@
 		var/mob/living/critter/flock/drone/flockdrone = pick(nearby_flockdrones)
 
 		if (!flockdrone.flock.isEnemy(attacker))
-			if (!attack_message_on_cd)
-				attack_message_on_cd = TRUE
-				SPAWN(attack_message_cd) attack_message_on_cd = FALSE
-
 			flock_speak(flockdrone, "Damage sighted on [source], [pick_string("flockmind.txt", "flockdrone_enemy")] [attacker]", flockdrone.flock)
 			flockdrone.flock.updateEnemy(attacker)
 
 			return
-
-		if (!attack_message_on_cd)
-			attack_message_on_cd = TRUE
-			SPAWN(attack_message_cd) attack_message_on_cd = FALSE
-
-			flock_speak(flockdrone, "[source] being attacked", flockdrone.flock)

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -370,6 +370,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\datums\effects\system\spark_spread.dm"
 #include "code\datums\effects\system\steam_spread.dm"
 #include "code\datums\flock\flock.dm"
+#include "code\datums\flock\flockprotection.dm"
 #include "code\datums\flock\flocktilegroup.dm"
 #include "code\datums\gamemodes\arcfiend.dm"
 #include "code\datums\gamemodes\assday_classic.dm"


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds a backend flock protection component. It's meant to be added to anything Flock owned, and it handles the cases of preventing Flockdrones from attacking the thing it's added to, as well as if attacking the thing is to be reported by a nearby Flockdrone or not.

This is a base component that will likely be modified later. It doesn't currently handle projectile attacks, and it doesn't handle distinguishing between stuff owned by different Flocks.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
For having anything Flock owned have the properties of being immune to Flockdrone attacks and being reported to be attacked automatically by a Flockdrone, this would help make a single place where this sort of code can be modified.