### PR TITLE
Prevent Flock floor tiles from being burned

### DIFF
--- a/code/turf/turf_flock.dm
+++ b/code/turf/turf_flock.dm
@@ -83,6 +83,8 @@
 			f.group?.removestructure(f)
 			f.group = null
 
+/turf/simulated/floor/feather/burn_tile()
+	return
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 // stuff to make floorrunning possible (god i wish i could think of a better verb than "floorrunning")


### PR DESCRIPTION
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just prevents Flock floor tiles from being burned.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes a bug where burned Flock floor tiles would show up as a black square due to not having a burned icon.

Not sure if they should be burned or not, but this fixes this until an icon is made.

Prevents the burnt = 1 variable from being set, which could fix other possible bugs or mess with something else.