### PR TITLE
Add some more system integrity messages

### DIFF
--- a/code/obj/flock/cage.dm
+++ b/code/obj/flock/cage.dm
@@ -10,6 +10,7 @@
 	icon_state = "cage"
 	steam_on_death = 0
 	health = 30
+	var/health_max = 30
 	alpha = 192
 	var/datum/flock/flock
 	var/mob/living/occupant = null // todo: make this work with more than just humans (borgs, critters, probably not cubes)
@@ -167,6 +168,7 @@
 	if(isflock(user))
 		return {"<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received.
 		<br><span class='bold'>ID:</span> Matter Reprocessor
+		<br><span class='bold'>System Integrity:</span> [round((src.health/src.health_max)*100)]%
 		<br><span class='bold'>Volume:</span> [src.reagents.get_reagent_amount(src.target_fluid)]
 		<br><span class='bold'>Needed volume:</span> [src.create_egg_at_fluid]
 		<br><span class='bold'>###=-</span></span>"}

--- a/code/obj/flock/furniture.dm
+++ b/code/obj/flock/furniture.dm
@@ -167,6 +167,7 @@
   if(isflock(user))
     return {"<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received.
     <br><span class='bold'>ID:</span> Containment Capsule
+	<br><span class='bold'>System Integrity:</span> [round((src.health_attack/src.health_max)*100)]%
     <br><span class='bold'>###=-</span></span>"}
   else
     return null // give the standard description
@@ -295,6 +296,7 @@
 	if(isflock(user))
 		return {"<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received.
 		<br><span class='bold'>ID:</span> Reinforced Barricade
+		<br><span class='bold'>System Integrity:</span> [round((src.health/src.health_max)*100)]%
 		<br><span class='bold'>###=-</span></span>"}
 	else
 		return null // give the standard description


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just adds system integrity messages, showing the health %, for Flock closets, cages, and barricades.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It adds a bit more depth, and it would be nice to be able to see the health of these structures.
