### PR TITLE
add special handling for card_groups

### DIFF
--- a/code/mob/living/critter/ai/flock/flocktasks.dm
+++ b/code/mob/living/critter/ai/flock/flocktasks.dm
@@ -579,6 +579,10 @@ butcher
 				var/obj/item/paper_bin/P = I
 				if(P.amount <= 0)
 					continue // do not try to fetch paper out of an empty paper bin forever
+			if(istype(I,/obj/item/card_group))
+				if(I.loc == holder.owner) //checks hand for card to allow taking from pockets/storage
+					holder.owner.u_equip(I)
+				holder.owner.put_in_hand_or_drop(I)
 			// if we can get a valid path to the target, include it for consideration
 			. += I
 	. = get_path_to(holder.owner, ., 40, 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Card groups pop a context-menu when you use them, instead of being picked up. I added special handling that emulates the pick-up-deck action.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Some items are weird.
