### PR TITLE
Add Flockcloset attackby restrictions

### DIFF
--- a/code/obj/flock/furniture.dm
+++ b/code/obj/flock/furniture.dm
@@ -113,28 +113,29 @@
 	setMaterial("gnesis")
 
 /obj/storage/closet/flock/attackby(obj/item/W as obj, mob/user as mob)
-	// handle tools
-	if (istype(W, /obj/item/cargotele))
-		boutput(user, "<span class='alert'>For some reason, it refuses to budge.</span>")
-		return
-	else if (istype(W, /obj/item/satchel/))
-		boutput(user, "<span class='alert'>It isn't really clear how to make this work.</span>")
-		return
-	else if (!src.open && isweldingtool(W))
-		if (W:try_weld(user,0,-1,0,0))
+	if (istype(W, /obj/item/grab))
+		return ..()
+
+	if (!src.open)
+		if (istype(W, /obj/item/cargotele))
+			boutput(user, "<span class='alert'>For some reason, it refuses to budge.</span>")
+		else if (isweldingtool(W) && W:try_weld(user,0,-1,0,0))
 			boutput(user, "<span class='alert'>It doesn't matter what you try, it doesn't seem to keep welded shut.</span>")
-		return
-	// smack the damn thing if it's closed
-	else if (!src.open && isitem(W))
-		var/force = W.force
-		// smack the damn thing
-		user.lastattacked = src
-		attack_particle(user,src)
-		playsound(src.loc, src.hitsound , 50, 1, pitch = 1.6)
-		src.take_damage(force, user)
-	// else if these special cases don't resolve things, throw it to the parent proc
+		else if (isitem(W))
+			var/force = W.force
+			user.lastattacked = src
+			attack_particle(user, src)
+			playsound(src.loc, src.hitsound, 50, 1, pitch = 1.6)
+			src.take_damage(force, user)
 	else
-		..()
+		if (istype(W, /obj/item/satchel/) && length(W.contents))
+			..()
+		else if (!issilicon(user))
+			if (istype(user, /mob/living/critter/flock/drone))
+				user.u_equip(W)
+				W?.set_loc(src.loc)
+			else if(user.drop_item())
+				W?.set_loc(src.loc)
 
 /obj/storage/closet/flock/proc/take_damage(var/force, var/mob/user as mob)
 	if (!isnum(force) || force <= 0)

--- a/code/obj/flock/furniture.dm
+++ b/code/obj/flock/furniture.dm
@@ -119,7 +119,7 @@
 	if (!src.open)
 		if (istype(W, /obj/item/cargotele))
 			boutput(user, "<span class='alert'>For some reason, it refuses to budge.</span>")
-		else if (isweldingtool(W) && W:try_weld(user,0,-1,0,0))
+		else if (isweldingtool(W) && W:try_weld(user, 0, -1, 0, 0))
 			boutput(user, "<span class='alert'>It doesn't matter what you try, it doesn't seem to keep welded shut.</span>")
 		else if (isitem(W))
 			var/force = W.force
@@ -128,7 +128,7 @@
 			playsound(src.loc, src.hitsound, 50, 1, pitch = 1.6)
 			src.take_damage(force, user)
 	else
-		if (istype(W, /obj/item/satchel/) && length(W.contents))
+		if (istype(W, /obj/item/satchel) && length(W.contents))
 			..()
 		else if (!issilicon(user))
 			if (istype(user, /mob/living/critter/flock/drone))


### PR DESCRIPTION
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just adds some restrictions to the Flockcloset, such as preventing disassembly by wrench or welding holes in it with a welding tool.

Also fixes Flockdrones not being able to put items in Flockclosets.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Stuff such as disassembly by wrench shouldn't be allowed.

Bug fix.