### PR TITLE
Fix creating barricades on tiles they shouldn't be able to be made on

### DIFF
--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -744,13 +744,17 @@
 		if(istype(target, /turf/simulated/floor/feather))
 			var/turf/simulated/floor/feather/flocktarget = target
 			if(user.a_intent == INTENT_DISARM)
-				if(!locate(/obj/grille/flock) in flocktarget)
-					if(user.resources < 25)
-						boutput(user, "<span class='alert'>Not enough resources to construct a barricade (you need 25).</span>")
-					else
-						actions.start(new/datum/action/bar/flock_construct(target), user)
+				for (var/atom/O in flocktarget.contents)
+					if (istype(O, /obj/grille/flock))
+						boutput(user, "<span class='alert'>There's already a barricade here.</span>")
+						return
+					if ((O.density && !isflock(O)) || istype(O, /obj/flock_structure/ghost))
+						boutput(user, "<span class='alert'>This tile has something that blocks barricade construction!</span>")
+						return
+				if (user.resources < 25)
+					boutput(user, "<span class='alert'>Not enough resources to construct a barricade (you need 25).</span>")
 				else
-					boutput(user, "<span class='alert'>There's already a barricade here.</span>")
+					actions.start(new/datum/action/bar/flock_construct(target), user)
 			else
 				boutput(user, "<span class='notice'>It's already been repurposed. Can't improve on perfection. (Use the disarm intent to construct a barricade.)</span>")
 		else


### PR DESCRIPTION
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR prevents creating barricades on tiles that have an object with density on them, excluding Flockdrones since they can move through barricades, and in-construction tealprints.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix.