### PR TITLE
Change how Flockwalls are deconstructed

### DIFF
--- a/code/mob/living/critter/flockcritter_parent.dm
+++ b/code/mob/living/critter/flockcritter_parent.dm
@@ -489,7 +489,7 @@
 				target = null
 			if(/turf/simulated/wall/auto/feather)
 				var/turf/simulated/wall/auto/feather/f = target
-				f.dismantle_wall()
+				f.destroy_resources()
 			if(/obj/machinery/door/feather)
 				var/turf/T = get_turf(target)
 				playsound(T, "sound/impact_sounds/Glass_Shatter_3.ogg", 25, 1)

--- a/code/turf/turf_flock.dm
+++ b/code/turf/turf_flock.dm
@@ -267,6 +267,13 @@ turf/simulated/floor/feather/proc/bfs(turf/start)//breadth first search, made by
   else
     return null // give the standard description
 
+/turf/simulated/wall/auto/feather/proc/destroy_resources()
+	src.ReplaceWith("/turf/simulated/floor/feather", FALSE)
+
+	if (map_settings?.auto_walls)
+		for (var/turf/simulated/wall/auto/feather/W in orange(1, src))
+			W.UpdateIcon()
+
 /turf/simulated/wall/auto/feather/Entered(var/mob/living/critter/flock/drone/F, atom/oldloc)
 	..()
 	if(!istype(F) || !oldloc)


### PR DESCRIPTION
[FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just changes how Flockwalls are deconstructed by Flockdrones. Instead of being turned into a gnesis girder with gnesis sheets over a gnesis floor tile, the wall will be replaced by a Flock floor tile, with no resources spawned (temporary).


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Feels like it doesn't make sense with how it's currently done.