### PR TITLE
Bring ghost Flocktrace offer up to date with other offers

### DIFF
--- a/code/datums/abilities/flock/flockmind.dm
+++ b/code/datums/abilities/flock/flockmind.dm
@@ -178,15 +178,14 @@
 
 /datum/targetable/flockmindAbility/partitionMind/cast(atom/target)
 	if(..())
-		return 1
+		return TRUE
+
 	if(!holder.pointCheck(100))
-		boutput(holder,"<span class='alert'>You need more compute to partition yourself</span>")
-		return 1
+		return TRUE
+
 	var/mob/living/intangible/flock/flockmind/F = holder.owner
-	if(F)
-		F.partition()
-	else
-		return 1 // not sure what happened here
+
+	return F.partition()
 
 /////////////////////////////////////////
 

--- a/code/mob/living/intangible/flock/flockmind.dm
+++ b/code/mob/living/intangible/flock/flockmind.dm
@@ -116,7 +116,39 @@
 		if(origin)
 			src.set_loc(get_turf(origin))
 
-// receive volunteers to be a promoted flockdrone
+
+/mob/living/intangible/flock/flockmind/proc/partition()
+	boutput(src, "<span class='notice'>Partitioning initiated. Stand by.</span>")
+
+	var/ghost_confirmation_delay = 30 SECONDS
+
+	var/list/text_messages = list()
+	text_messages.Add("Would you like to respawn as a Flocktrace? Your name will be added to the list of eligible candidates.")
+	text_messages.Add("You are eligible to be respawned as a Flocktrace. You have [ghost_confirmation_delay / 10] seconds to respond to the offer.")
+	text_messages.Add("You have been added to the list of eligible candidates. The game will pick a player soon. Good luck!")
+
+	message_admins("Sending Flocktrace offer to eligible ghosts. They have [ghost_confirmation_delay / 10] seconds to respond.")
+	var/list/candidates = dead_player_list(FALSE, ghost_confirmation_delay, text_messages)
+
+	if (!src) // doesnt work yet
+		message_admins("[src.real_name] has died during a Flocktrace respawn offer event.")
+		logTheThing("admin", null, null, "No Flocktraces were created for [src.real_name] due to their death.")
+		return TRUE
+
+	if (!length(candidates))
+		message_admins("No ghosts responded to a Flocktrace offer from [src.real_name]")
+		logTheThing("admin", null, null, "No ghosts responded to Flocktrace offer from [src.real_name]")
+		boutput(src, "<span class='alert'>Unable to partition, please try again later.</span>")
+		return TRUE
+
+	var/mob/picked = pick(candidates)
+
+	message_admins("[picked.key] respawned as a Flocktrace under [src.real_name].")
+	logTheThing("admin", picked.key, null, "respawned as a Flocktrace under [src.real_name].")
+
+	picked.make_flocktrace(get_turf(src), src.flock)
+
+// old code for flocktrace respawns
 /datum/ghost_notification/respawn/flockdrone
 	respawn_explanation = "flockmind partition"
 	icon = 'icons/misc/featherzone.dmi'
@@ -141,9 +173,3 @@
 		message_admins("[key_name(src)] made [key_name(trace)] a flocktrace via ghost volunteer respawn.")
 		logTheThing("admin", src, trace, "made [key_name(trace)] a flocktrace via ghost volunteer respawn.")
 		flock_speak(null, "Trace partition \[ [trace.real_name] \] has been instantiated.", src.flock)
-
-/mob/living/intangible/flock/flockmind/proc/partition()
-	// send out a request to ghosts
-	ghost_notifier.send_notification(src, src, /datum/ghost_notification/respawn/flockdrone)
-	boutput(src, "<span class='notice'>Partitioning initiated. Stand by.</span>")
-

--- a/code/mob/transform_procs.dm
+++ b/code/mob/transform_procs.dm
@@ -887,10 +887,13 @@ var/respawn_arena_enabled = 0
 			ticker.minds += O.mind
 		qdel(src)
 
-		boutput(O, "<span class='bold'>You are a flocktrace, a partition of the flock's collective computation!</span>")
-		boutput(O, "<span class='bold'>Your loyalty is to the flock and to the flockmind. Spread drones, convert the station, aid in the construction of the Relay.</span>")
+		boutput(O, "<span class='bold'>You are a Flocktrace, a partition of the Flock's collective computation!</span>")
+		boutput(O, "<span class='bold'>Your loyalty is to the Flock of [flock.flockmind.real_name]. Spread drones, convert the station, and aid in the construction of the Relay.</span>")
 		boutput(O, "<span class='bold'>In this form, you cannot be harmed, but you can't do anything to the world at large.</span>")
-		boutput(O, "<span class='italic'>Tip: click-drag yourself onto unoccupied drones to take direct control of them.</span>")
+		boutput(O, "<span class='italic'>Tip: Click-drag yourself onto unoccupied drones to take direct control of them.</span>")
 		boutput(O, "<span class='notice'>You are part of the <span class='bold'>[flock.name]</span> flock.</span>")
+
+		flock_speak(null, "Trace partition [O.real_name] has been instantiated.", flock)
+
 		return O
 	return null


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR brings the ghost Flocktrace offer up to date, making it TGUI, and allowing for declining all future Flocktrace offers.

The standardized way for getting candidates, dead_player_list(), is used.

Currently the Flockmind's death seems to still allow Flocktraces to spawn, not sure why. May just be the way I'm testing it.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It allows for a standardized way of getting candidates.

Declining future Flocktrace offers would be nice if you aren't interested. Fixes #8.