### PR TITLE
Add flock control panel to abilities after rift spawn

### DIFF
--- a/code/datums/abilities/flock/flockmind.dm
+++ b/code/datums/abilities/flock/flockmind.dm
@@ -355,8 +355,8 @@
 /////////////////////////////////////////
 
 /datum/targetable/flockmindAbility/controlPanel
-	name = "Flock Control"
-	desc = "(TEMPORARY) Open flock control panel."
+	name = "Flock Control Panel"
+	desc = "Open the Flock control panel."
 	icon_state = "radio_stun"
 	targeted = 0
 	cooldown = 0

--- a/code/mob/living/intangible/flock/flockmind.dm
+++ b/code/mob/living/intangible/flock/flockmind.dm
@@ -26,7 +26,6 @@
 	src.update_name_tag()
 	src.flock.registerFlockmind(src)
 	src.flock.showAnnotations(src)
-	src.addAbility(/datum/targetable/flockmindAbility/controlPanel)
 	src.addAbility(/datum/targetable/flockmindAbility/spawnEgg)
 
 /mob/living/intangible/flock/flockmind/special_desc(dist, mob/user)
@@ -76,6 +75,7 @@
 	src.addAllAbilities()
 
 /mob/living/intangible/flock/flockmind/proc/addAllAbilities()
+	src.addAbility(/datum/targetable/flockmindAbility/controlPanel)
 	src.addAbility(/datum/targetable/flockmindAbility/designateTile)
 	src.addAbility(/datum/targetable/flockmindAbility/designateEnemy)
 	src.addAbility(/datum/targetable/flockmindAbility/partitionMind)


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just makes it so that the Flock Control Panel ability is added to your abilities after spawning your rift.

It also changes the name and description of the ability slightly.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's not used before spawning the rift. Just minor cleanup.