### PR TITLE
Fix flocktraces dying at 100 compute

### DIFF
--- a/code/mob/living/intangible/flock/flocktrace.dm
+++ b/code/mob/living/intangible/flock/flocktrace.dm
@@ -72,8 +72,8 @@
 		return 1
 	var/datum/abilityHolder/flockmind/aH = src.abilityHolder
 	aH.updateCompute()
-	if (src.flock && src.flock.total_compute() <= src.flock.used_compute())
-		boutput(src, "<span class='alert'>There are insufficient drones left in the flock to compute your consciousness!</span>")
+	if (src.flock && src.flock.total_compute() < src.flock.used_compute())
+		boutput(src, "<span class='alert'>The Flock has insufficient compute to sustain your consciousness!</span>")
 		src.death() // get rekt
 
 /mob/living/intangible/flock/trace/death(gibbed)


### PR DESCRIPTION
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes a bug where Flocktraces would die at 100 compute, and likely multiples of 100.

Also changes one of the Flocktrace death messages a little.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix.