### PR TITLE
Flockdrone projectile buff

### DIFF
--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -885,7 +885,8 @@
 	color_green = 0.9
 	color_blue = 0.8
 	disruption = 10
-
+	hit_ground_chance = 50
+	ks_ratio = 0.1
 /////////////////////////////////////////////////////////////////////////////////
 
 /datum/equipmentHolder/flockAbsorption


### PR DESCRIPTION

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Flockdrone projectiles can now hit targets that are lying down, and cause a small amount of burn damage also.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Flockdrones are useless if you're lying down. And being repeatedly stunned is frequently little more than annoying.



