### PR TITLE
Makes flockdrone density work properly

### DIFF
--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -217,7 +217,7 @@
 
 /mob/living/critter/flock/drone/Cross(atom/movable/mover)
 	if(isflock(mover))
-		return 1
+		return TRUE
 	else
 		return !src.density
 

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -219,7 +219,7 @@
 	if(isflock(mover))
 		return 1
 	else
-		return 0
+		return !src.density
 
 /mob/living/critter/flock/drone/MouseDrop_T(mob/living/target, mob/user)
 	if(!target || !user)
@@ -524,6 +524,18 @@
 				src.icon_state = "drone-d2"
 	return
 
+/mob/living/critter/flock/drone/proc/reduce_lifeprocess_on_death() //used for AI mobs we dont give a dang about them after theyre dead
+	remove_lifeprocess(/datum/lifeprocess/blood)
+	remove_lifeprocess(/datum/lifeprocess/canmove)
+	remove_lifeprocess(/datum/lifeprocess/disability)
+	remove_lifeprocess(/datum/lifeprocess/fire)
+	remove_lifeprocess(/datum/lifeprocess/hud)
+	remove_lifeprocess(/datum/lifeprocess/mutations)
+	remove_lifeprocess(/datum/lifeprocess/organs)
+	remove_lifeprocess(/datum/lifeprocess/sight)
+	remove_lifeprocess(/datum/lifeprocess/skin)
+	remove_lifeprocess(/datum/lifeprocess/statusupdate)
+
 /mob/living/critter/flock/drone/death(var/gibbed)
 	if(src.floorrunning)
 		src.end_floorrunning()
@@ -548,6 +560,7 @@
 	..()
 	src.icon_state = "drone-dead"
 	playsound(src, "sound/impact_sounds/Glass_Shatter_3.ogg", 50, 1)
+	src.reduce_lifeprocess_on_death()
 	src.set_density(0)
 	desc = "[initial(desc)]<br><span class='alert'>\The [src] is a dead, broken heap.</span>"
 	src.remove_simple_light("drone_light")

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -561,7 +561,7 @@
 	src.icon_state = "drone-dead"
 	playsound(src, "sound/impact_sounds/Glass_Shatter_3.ogg", 50, 1)
 	src.reduce_lifeprocess_on_death()
-	src.set_density(0)
+	src.set_density(FALSE)
 	desc = "[initial(desc)]<br><span class='alert'>\The [src] is a dead, broken heap.</span>"
 	src.remove_simple_light("drone_light")
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Flockdrone corpses no longer block movement or bullets. Also death of a drone ends all lifeprocesses because it ought to, and it was making things dense when they weren't supposed to be.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #132

