### PR TITLE
Change Flockmind death condition

### DIFF
--- a/code/mob/living/intangible/flock/flockmind.dm
+++ b/code/mob/living/intangible/flock/flockmind.dm
@@ -58,9 +58,14 @@
 
 /mob/living/intangible/flock/flockmind/Life(datum/controller/process/mobs/parent)
 	if (..(parent))
-		return 1
-	if (src.started && src.flock && src.flock.total_compute() <= 0)
-		src.death() // get rekt
+		return TRUE
+	if (src.started && src.flock)
+		if (src.flock.getComplexDroneCount())
+			return
+		for (var/obj/flock_structure/s in src.flock.structures)
+			if (istype(s, /obj/flock_structure/egg) || istype(s, /obj/flock_structure/rift))
+				return
+		src.death()
 
 /mob/living/intangible/flock/flockmind/proc/spawnEgg()
 	if(src.flock)

--- a/code/obj/flock/structure/egg.dm
+++ b/code/obj/flock/structure/egg.dm
@@ -11,7 +11,6 @@
 	flock_id = "Second-Stage Assembler"
 	build_time = 6
 	health = 30 // fragile little thing
-	compute = 1 //just to make sure that you don't die seconds before a drone hatches
 	var/decal_made = 0 // for splashing stuff on throw
 
 /obj/flock_structure/egg/New(var/atom/location, var/datum/flock/F=null)

--- a/code/obj/flock/structure/rift.dm
+++ b/code/obj/flock/structure/rift.dm
@@ -12,6 +12,12 @@
 	health = 200 // stronk little thing
 	var/decal_made = 0 // for splashing stuff on throw
 	var/list/eject = list()
+	var/mainflock = null // for when a flockmind is spawning the little shits(read:drones) get assigned to it
+
+/obj/flock_structure/rift/New(var/atom/location, var/datum/flock/F=null)
+	..()
+	if(src.flock)
+		src.flock.registerUnit(src)
 
 /obj/flock_structure/rift/building_specific_info()
 	var/time_remaining = round(src.build_time - getTimeInSecondsSinceTime(src.time_started))
@@ -29,7 +35,6 @@
 		for(var/i=1, i<5, i++)
 			var/obj/flock_structure/egg/e = new(src.contents, src.flock)
 			eject += e
-			e.flock = mainflock
 		var/list/candidate_turfs = list()
 		for(var/turf/simulated/floor/S in orange(src, 4))
 			candidate_turfs += S
@@ -43,7 +48,6 @@
 					candidate_turfs -= S
 					break
 		flockdronegibs(src.loc, null, eject)//here they are actually ejected
-		src.flock?.removeDrone(src)
 		qdel(src)
 	else
 		var/severity = round(((build_time - elapsed)/build_time) * 5)

--- a/code/obj/flock/structure/rift.dm
+++ b/code/obj/flock/structure/rift.dm
@@ -35,6 +35,7 @@
 		for(var/i=1, i<5, i++)
 			var/obj/flock_structure/egg/e = new(src.contents, src.flock)
 			eject += e
+			e.flock = mainflock
 		var/list/candidate_turfs = list()
 		for(var/turf/simulated/floor/S in orange(src, 4))
 			candidate_turfs += S
@@ -48,6 +49,7 @@
 					candidate_turfs -= S
 					break
 		flockdronegibs(src.loc, null, eject)//here they are actually ejected
+		src.flock?.removeDrone(src)
 		qdel(src)
 	else
 		var/severity = round(((build_time - elapsed)/build_time) * 5)

--- a/code/obj/flock/structure/rift.dm
+++ b/code/obj/flock/structure/rift.dm
@@ -10,15 +10,8 @@
 	flock_id = "Entry Rift"
 	build_time = 10
 	health = 200 // stronk little thing
-	compute = 5
 	var/decal_made = 0 // for splashing stuff on throw
 	var/list/eject = list()
-	var/mainflock = null // for when a flockmind is spawning the little shits(read:drones) get assigned to it
-
-/obj/flock_structure/rift/New(var/atom/location, var/datum/flock/F=null)
-	..()
-	if(src.flock)
-		src.flock.registerUnit(src)
 
 /obj/flock_structure/rift/building_specific_info()
 	var/time_remaining = round(src.build_time - getTimeInSecondsSinceTime(src.time_started))


### PR DESCRIPTION
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR changes the Flockmind death condition to check for drones and certain structures rather than compute.

Fixes a bug where the Flockmind would still be alive even if all drones were dead.

Also, it structures the Flockmind death check in a way that removes the need for the Flock rift and eggs to have compute and allows future added objects or flock structures to be checked in the death check.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix (If the Flockmind loses all its drones but still has sources of compute, it cannot do anything.).

Don't think it makes sense for rift and eggs to provide compute.