### PR TITLE
Allow Flock protection component to handle projectiles

### DIFF
--- a/code/datums/flock/flockprotection.dm
+++ b/code/datums/flock/flockprotection.dm
@@ -2,15 +2,18 @@
 	var/flockdrones_can_hit
 	var/report_hand_attack
 	var/report_obj_attack
+	var/report_proj_attack
 
-/datum/component/flock_protection/Initialize(flockdrones_can_hit, report_hand_attack, report_obj_attack)
+/datum/component/flock_protection/Initialize(flockdrones_can_hit, report_hand_attack, report_obj_attack, report_proj_attack)
 	src.flockdrones_can_hit = flockdrones_can_hit
 	src.report_hand_attack = report_hand_attack
 	src.report_obj_attack = report_obj_attack
+	src.report_proj_attack = report_proj_attack
 
 /datum/component/flock_protection/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_ATTACKHAND, .proc/handle_attackhand)
 	RegisterSignal(parent, COMSIG_ATTACKBY, .proc/handle_attackby)
+	RegisterSignal(parent, COMSIG_ATOM_HITBY_PROJ, .proc/handle_hitby)
 
 /datum/component/flock_protection/proc/handle_attackhand(source, mob/user as mob)
 	if (user.a_intent != INTENT_HARM)
@@ -61,6 +64,13 @@
 				src.attempt_report_attack(source, user)
 		else
 			src.attempt_report_attack(source, user)
+
+/datum/component/flock_protection/proc/handle_hitby(source, obj/projectile/P)
+	var/mob/attacker = P.shooter
+	if(!istype(attacker))
+		return
+	if (!istype(attacker, /mob/living/critter/flock/drone) && report_proj_attack)
+		src.attempt_report_attack(source, attacker)
 
 /datum/component/flock_protection/proc/attempt_report_attack(source, mob/attacker)
 	var/list/nearby_flockdrones = list()

--- a/code/mob/living/critter/flock/flockbit.dm
+++ b/code/mob/living/critter/flock/flockbit.dm
@@ -23,7 +23,7 @@
 	src.real_name = "[pick(consonants_upper)].[rand(10,99)].[rand(10,99)]"
 	src.update_name_tag()
 
-	src.AddComponent(/datum/component/flock_protection, FALSE, TRUE, TRUE)
+	src.AddComponent(/datum/component/flock_protection, FALSE, TRUE, TRUE, TRUE)
 
 /mob/living/critter/flock/bit/special_desc(dist, mob/user)
 	if(isflock(user))

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -63,7 +63,7 @@
 			emote("beep")
 			say(pick_string("flockmind.txt", "flockdrone_created"))
 
-	src.AddComponent(/datum/component/flock_protection, FALSE, FALSE, FALSE)
+	src.AddComponent(/datum/component/flock_protection, FALSE, FALSE, FALSE, FALSE)
 
 /mob/living/critter/flock/drone/disposing()
 	src.remove_simple_light("drone_light")

--- a/code/obj/flock/cage.dm
+++ b/code/obj/flock/cage.dm
@@ -39,7 +39,7 @@
 		processing_items |= src
 		src.setMaterial(getMaterial("gnesis"))
 		src.health = src.health_max
-		src.AddComponent(/datum/component/flock_protection, FALSE, TRUE, TRUE)
+		src.AddComponent(/datum/component/flock_protection, FALSE, TRUE, TRUE, TRUE)
 
 	proc/getHumanPiece(var/mob/living/carbon/human/H)
 		// prefer inventory items before limbs, and limbs before organs

--- a/code/obj/flock/furniture.dm
+++ b/code/obj/flock/furniture.dm
@@ -111,7 +111,7 @@
 /obj/storage/closet/flock/New()
 	..()
 	setMaterial("gnesis")
-	src.AddComponent(/datum/component/flock_protection, FALSE, FALSE, TRUE)
+	src.AddComponent(/datum/component/flock_protection, FALSE, FALSE, TRUE, TRUE)
 
 /obj/storage/closet/flock/attackby(obj/item/W as obj, mob/user as mob)
 	if (istype(W, /obj/item/grab))
@@ -191,7 +191,7 @@
 /obj/machinery/light/flock/New()
 	..()
 	light.set_color(0.45, 0.75, 0.675)
-	src.AddComponent(/datum/component/flock_protection, TRUE, FALSE, TRUE)
+	src.AddComponent(/datum/component/flock_protection, TRUE, FALSE, TRUE, FALSE)
 
 /obj/machinery/light/flock/attack_hand(mob/user)
 	if(isflock(user))
@@ -224,7 +224,7 @@
 /obj/lattice/flock/New()
 	..()
 	setMaterial("gnesis")
-	src.AddComponent(/datum/component/flock_protection, FALSE, FALSE, TRUE)
+	src.AddComponent(/datum/component/flock_protection, FALSE, FALSE, TRUE, FALSE)
 
 /obj/lattice/flock/attackby(obj/item/C as obj, mob/user as mob)
 	if (istype(C, /obj/item/tile))
@@ -285,7 +285,7 @@
 	..()
 	setMaterial("gnesis")
 	src.UpdateIcon()
-	src.AddComponent(/datum/component/flock_protection, FALSE, TRUE, TRUE)
+	src.AddComponent(/datum/component/flock_protection, FALSE, TRUE, TRUE, TRUE)
 
 
 // flockdrones can always move through

--- a/code/obj/flock/structure/flock_structure_parent.dm
+++ b/code/obj/flock/structure/flock_structure_parent.dm
@@ -44,7 +44,7 @@
 		group = f.group
 		f.group.addstructure(src)
 
-	src.AddComponent(/datum/component/flock_protection, FALSE, TRUE, TRUE)
+	src.AddComponent(/datum/component/flock_protection, FALSE, TRUE, TRUE, TRUE)
 
 /obj/flock_structure/disposing()
 	processing_items -= src

--- a/code/obj/machinery/door/feather.dm
+++ b/code/obj/machinery/door/feather.dm
@@ -13,7 +13,7 @@
 /obj/machinery/door/feather/New()
 	..()
 	setMaterial("gnesis")
-	src.AddComponent(/datum/component/flock_protection, FALSE, FALSE, TRUE)
+	src.AddComponent(/datum/component/flock_protection, FALSE, FALSE, TRUE, TRUE)
 
 /obj/machinery/door/feather/special_desc(dist, mob/user)
 	if(isflock(user))

--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -1055,7 +1055,7 @@
 
 /obj/window/feather/New()
 	..()
-	src.AddComponent(/datum/component/flock_protection, FALSE, TRUE, TRUE)
+	src.AddComponent(/datum/component/flock_protection, FALSE, TRUE, TRUE, TRUE)
 
 /obj/window/feather/special_desc(dist, mob/user)
   if(isflock(user))

--- a/code/turf/turf_flock.dm
+++ b/code/turf/turf_flock.dm
@@ -36,7 +36,7 @@
 	src.checknearby() //check for nearby groups
 	if(!group)//if no group found
 		initializegroup() //make a new one
-	src.AddComponent(/datum/component/flock_protection, FALSE, FALSE, TRUE)
+	src.AddComponent(/datum/component/flock_protection, FALSE, FALSE, TRUE, FALSE)
 
 /turf/simulated/floor/feather/special_desc(dist, mob/user)
   if(isflock(user))
@@ -272,7 +272,7 @@ turf/simulated/floor/feather/proc/bfs(turf/start)//breadth first search, made by
 	..()
 	setMaterial(getMaterial("gnesis"))
 	src.health = src.max_health
-	src.AddComponent(/datum/component/flock_protection, FALSE, TRUE, TRUE)
+	src.AddComponent(/datum/component/flock_protection, FALSE, TRUE, TRUE, TRUE)
 
 /turf/simulated/wall/auto/feather/special_desc(dist, mob/user)
   if(isflock(user))


### PR DESCRIPTION
[FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR allows the Flock protection component to handle projectile attacks.

Currently projectiles from grenades, like stinger grenades, are not accounted for. Not sure if it is possible to add at the moment.

Shooting a wall with an energy projectile still marks you as an enemy.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Shooting Flock stuff doesn't currently mark you as an enemy, meaning you can shoot Flock stuff without anything bad happening to you.