### PR TITLE
Fixes AI drones not being able to attack

### DIFF
--- a/code/mob/living/critter/ai/flock/flocktasks.dm
+++ b/code/mob/living/critter/ai/flock/flocktasks.dm
@@ -659,7 +659,7 @@ butcher
 			if(owncritter.active_hand != 3) // stunner
 				owncritter.set_hand(3)
 			owncritter.set_dir(get_dir(owncritter, holder.target))
-			owncritter.hand_attack(holder.target, dummy_params)
+			owncritter.hand_range_attack(holder.target, dummy_params)
 			if(dist < run_range)
 				// RUN
 				walk_away(owncritter, holder.target, 1, 4)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #141
So it turns out that if you set `can_attack` to true on a ranged critter limb, they will only ever try to melee attack unless you explicitly force them to ranged attack, leading to drones just sitting several tiles away trying to grab their target.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Drones being able to attack is good