### PR TITLE
Give Flockdrones and Flockbits radiation immunity

### DIFF
--- a/code/mob/living/critter/flockcritter_parent.dm
+++ b/code/mob/living/critter/flockcritter_parent.dm
@@ -51,8 +51,8 @@
 /mob/living/critter/flock/New(var/atom/L, var/datum/flock/F=null)
 	..()
 
-	// throw away the ability holder
 	qdel(abilityHolder)
+	APPLY_ATOM_PROPERTY(src, PROP_MOB_RADPROT, src, 100)
 
 	// do not automatically set up a flock if one is not provided
 	// flockless drones act differently


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just gives Flockdrones and Flockbits radiation immunity.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
They can't receive toxin damage, it doesn't seem right when a health analyzer shows a Flockdrone or Flockbit having radiation poisoning.