### PR TITLE
Mark people who throw objects at Flockdrones as enemies

### DIFF
--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -460,7 +460,7 @@
 /mob/living/critter/flock/drone/hitby(atom/movable/AM, datum/thrown_thing/thr)
 	. = ..()
 	var/mob/attacker = thr.user
-	if(istype(attacker) && !istype(attacker, /mob/living/critter/flock/drone))
+	if(istype(attacker) && !isflock(attacker))
 		src.harmedBy(attacker)
 
 /mob/living/critter/flock/drone/attackby(var/obj/item/I, var/mob/M)

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -457,6 +457,12 @@
 		if(istype(attacker))
 			src.harmedBy(attacker)
 
+/mob/living/critter/flock/drone/hitby(atom/movable/AM, datum/thrown_thing/thr)
+	. = ..()
+	var/mob/attacker = thr.user
+	if(istype(attacker) && !istype(attacker, /mob/living/critter/flock/drone))
+		src.harmedBy(attacker)
+
 /mob/living/critter/flock/drone/attackby(var/obj/item/I, var/mob/M)
 	// check whatever reagents are about to get dumped on us
 	var/has_harmful_chemicals = 0


### PR DESCRIPTION
[FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes it so that anyone who throws an object at a Flockdrone, that hits the Flockdrone, is marked as an enemy.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently, hitting a Flockdrone with a thrown object does damage to it, but you aren't marked as an enemy.