### PR TITLE
Prevent setting signals for Flockdoors with multitools

### DIFF
--- a/code/obj/machinery/door/feather.dm
+++ b/code/obj/machinery/door/feather.dm
@@ -13,6 +13,8 @@
 /obj/machinery/door/feather/New()
 	..()
 	setMaterial("gnesis")
+	var/datum/component/C = src.GetComponent(/datum/component/mechanics_holder)
+	C.RemoveComponent()
 	src.AddComponent(/datum/component/flock_protection, FALSE, FALSE, TRUE)
 
 /obj/machinery/door/feather/special_desc(dist, mob/user)

--- a/code/obj/machinery/door/feather.dm
+++ b/code/obj/machinery/door/feather.dm
@@ -14,7 +14,7 @@
 	..()
 	setMaterial("gnesis")
 	var/datum/component/C = src.GetComponent(/datum/component/mechanics_holder)
-	C.RemoveComponent()
+	C?.RemoveComponent()
 	src.AddComponent(/datum/component/flock_protection, FALSE, FALSE, TRUE)
 
 /obj/machinery/door/feather/special_desc(dist, mob/user)


### PR DESCRIPTION
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes a bug where you could set signals for Flockdoors with a multitool.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix.