### PR TITLE
Make minor Flock structure attack adjustments/improvements

### DIFF
--- a/code/obj/flock/structure/flock_structure_parent.dm
+++ b/code/obj/flock/structure/flock_structure_parent.dm
@@ -152,14 +152,17 @@
 	qdel(src)
 
 /obj/flock_structure/attack_hand(var/mob/user)
+	user.lastattacked = src
+
 	if(user.a_intent == INTENT_HARM)
 		if(isflock(user))
 			boutput(user, "<span class='alert'>You find you can't bring yourself to harm [src]!</span>")
 		else
 			user.visible_message("<span class='alert'><b>[user]</b> punches [src]! It's very ineffective!</span>")
-			playsound(src.loc, "sound/impact_sounds/Crystal_Hit_1.ogg", 80, 1)
-			src.takeDamage("brute", 1)
 			src.report_attack()
+			src.takeDamage("brute", 1)
+			playsound(src.loc, "sound/impact_sounds/Crystal_Hit_1.ogg", 80, 1)
+
 	else
 		var/action = ""
 		switch(user.a_intent)
@@ -170,20 +173,18 @@
 			if(INTENT_GRAB)
 				action = "squeezes"
 		src.visible_message("<span class='alert'><b>[user]</b> [action] [src], but nothing happens.</span>")
-	user.lastattacked = src
 
 /obj/flock_structure/attackby(obj/item/W as obj, mob/user as mob)
 	src.visible_message("<span class='alert'><b>[user]</b> attacks [src] with [W]!</span>")
-	playsound(src.loc, "sound/impact_sounds/Crystal_Hit_1.ogg", 80, 1)
 	src.report_attack()
+	user.lastattacked = src
 
 	var/damtype = "brute"
 	if (W.hit_type == DAMAGE_BURN)
 		damtype = "fire"
 
 	takeDamage(damtype, W.force)
-
-	user.lastattacked = src
+	playsound(src.loc, "sound/impact_sounds/Crystal_Hit_1.ogg", 80, 1)
 
 /obj/flock_structure/proc/report_attack()
 	if (!ON_COOLDOWN(src, "attack_alert", 10 SECONDS))

--- a/code/obj/flock/structure/flock_structure_parent.dm
+++ b/code/obj/flock/structure/flock_structure_parent.dm
@@ -193,6 +193,8 @@
 		flock_speak(src, "ALERT: Under attack", flock)
 
 /obj/flock_structure/ex_act(severity)
+	src.report_attack()
+	
 	var/damage = 0
 	var/damage_mult = 1
 	switch(severity)
@@ -206,8 +208,6 @@
 			damage = rand(10,20)
 			damage_mult = 2
 	src.takeDamage("mixed", damage * damage_mult)
-
-	src.report_attack()
 
 /obj/flock_structure/bullet_act(var/obj/projectile/P)
 	src.report_attack()
@@ -240,12 +240,13 @@
 
 
 /obj/flock_structure/blob_act(var/power)
+	src.visible_message("<span class='alert'>[src] is hit by the blob!/span>")
+	src.report_attack()
+
 	var/modifier = power / 20
 	var/damage = rand(modifier, 12 + 8 * modifier)
 
 	takeDamage("mixed", damage)
-	src.visible_message("<span class='alert'>[src] is hit by the blob!/span>")
-	src.report_attack()
 
 /obj/flock_structure/Cross(atom/movable/mover)
 	. = ..()

--- a/code/obj/flock/structure/flock_structure_parent.dm
+++ b/code/obj/flock/structure/flock_structure_parent.dm
@@ -152,6 +152,7 @@
 	qdel(src)
 
 /obj/flock_structure/attack_hand(var/mob/user)
+	attack_particle(user, src)
 	user.lastattacked = src
 
 	if(user.a_intent == INTENT_HARM)
@@ -177,6 +178,7 @@
 /obj/flock_structure/attackby(obj/item/W as obj, mob/user as mob)
 	src.visible_message("<span class='alert'><b>[user]</b> attacks [src] with [W]!</span>")
 	src.report_attack()
+	attack_particle(user, src)
 	user.lastattacked = src
 
 	var/damtype = "brute"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just makes some minor adjustments/improvements for Flock structure attacks.

Some lines for effects were moved to before taking damage, so that any reporting of attacks and other similarly timed effects happen before the Flock structure is destroyed.

Some sound lines were moved to after the structure is destroyed, so that when destroying a Flock structure only one sound is played.

Attack particles for attacking by hand and with an object were added too.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Adjustments/improvements for proper ordering of effects.

Attack particles would be nice for hit feedback.