### PR TITLE
Prevent buckling of Flockdrones and Flockbits

### DIFF
--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -83,7 +83,7 @@
 			return ..()
 
 	proc/can_buckle(var/mob/living/to_buckle, var/mob/user)
-		if (!istype(to_buckle) || isintangible(to_buckle)) //no buckling AI-eyes
+		if (!istype(to_buckle) || isintangible(to_buckle) || isflock(to_buckle)) //no buckling AI-eyes
 			return FALSE
 		if (!ticker)
 			boutput(user, "You can't buckle anyone in before the game starts.")


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just makes it so that Flockdrones and Flockbits can't be buckled.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Flockdrones and Flockbits if buckled just stay buckled right now. Handling buckling requires touching AI code, posing a bit of a hassle, and besides the gimmick of buckling, there isn't really anything desired in being able to buckle one.