### PR TITLE
Prevent Flockdrones from entering vehicles

### DIFF
--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -977,6 +977,10 @@
 		boutput(boarder, "<span class='alert'>You have no idea how to work this.</span>")
 		return
 
+	if(isflock(boarder))
+		boutput(boarder, "<span class='alert'>You're unable to use this vehicle!</span>")
+		return
+
 	if(locked)
 		boutput(boarder, "<span class='alert'>[src] is locked!</span>")
 		return


### PR DESCRIPTION
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR prevents Flockdrones from entering vehicles.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
They shouldn't be able to given the number of Flockdrones you could have and what a Flockdrone could do if able to pilot a vehicle in respect to their intended functions.

Fixes #137.