### PR TITLE
Prevent runtimes on flock fires

### DIFF
--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -659,8 +659,8 @@
 				var/mob/living/carbon/human/H = owner
 				prot = (1 - (H.get_heat_protection() / 100))
 
-			if (H.traitHolder?.hasTrait("burning")) //trait 'burning' is human torch
-				duration += timePassed										//this makes the fire counter not increment on its own
+			if (H?.traitHolder?.hasTrait("burning")) //trait 'burning' is human torch
+				duration += timePassed //this makes the fire counter not increment on its own
 
 			if(ismob(owner) && owner:is_heat_resistant())
 				prot = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #156 by just adding a ?. check to a bit of code that assumes a status holder is human. Shouldn't affect anything except fix the occasional runtime and make burning damage work properly on /mob/living/ subclasses.

