### PR TITLE
Fix some Flockdrone healing bugs

### DIFF
--- a/code/datums/abilities/flock/flockmind.dm
+++ b/code/datums/abilities/flock/flockmind.dm
@@ -202,6 +202,8 @@
 	if (target.get_health_percentage() >= 1)
 		boutput(holder.owner, "<span class='notice'>[target.real_name] has no damage!</span>")
 		return TRUE
+	if (isdead(target))
+		return TRUE
 
 	playsound(holder.owner, "sound/misc/flockmind/flockmind_cast.ogg", 80, 1)
 	boutput(holder.owner, "<span class='notice'>You focus the flock's efforts on fixing [target.real_name]</span>")

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -498,8 +498,10 @@
 // also maybe we've just had environmental damage, who knows
 /mob/living/critter/flock/drone/TakeDamage(zone, brute, burn, tox, damage_type, disallow_limb_loss)
 	..()
-	var/prev_damaged = src.damaged
 	src.check_health()
+	if (brute <= 0 && burn <= 0 && tox <= 0)
+		return
+	var/prev_damaged = src.damaged
 	if(!isdead(src) && src.is_npc)
 		// if we've been damaged a new stage, call it out
 		if(prev_damaged != src.damaged && src.damaged > 0)
@@ -842,6 +844,8 @@
 	if(isflock(F))
 		if(F.get_health_percentage() >= 1.0)
 			boutput(user, "<span class='alert'>They don't need to be repaired, they're in perfect condition.</span>")
+			return
+		if (isdead(F))
 			return
 		if(user.resources < 10)
 			boutput(user, "<span class='alert'>Not enough resources to repair (you need 10).</span>")

--- a/code/mob/living/critter/flockcritter_parent.dm
+++ b/code/mob/living/critter/flockcritter_parent.dm
@@ -391,6 +391,8 @@
 					D.icon_state = "door1"//make it not look broke
 			else
 				T.HealDamage("All", T.health_brute / 3, T.health_burn / 3)
+				if (T.is_npc)
+					T.ai.interrupt()
 			F.pay_resources(10)
 
 /////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes being able to heal dead Flockdrones with the Concentrated Repair Burst ability, Flockdrones being able to heal dead Flockdrones, healing Flockdrones as a Flockdrone making them call out that they have been damaged, and healing Flockdrones as a Flockdrone causing them to wait forever.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fixes.