### PR TITLE
Adds a tick() call to interrupt

### DIFF
--- a/code/mob/living/critter/ai.dm
+++ b/code/mob/living/critter/ai.dm
@@ -98,6 +98,7 @@ var/list/ai_move_scheduled = list()
 			current_task?.reset()
 			current_task = default_task
 			stop_move()
+			tick()
 
 	proc/die()
 		src.enabled = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This just makes it so that interrupt immediately starts the next task instead of waiting for the next AI tick cycle. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes flockdrones react significantly faster in combat (and when manually ordered by #181), allowing a decent number of them an actual chance at caging someone trying to punch them.
I'm scared that there's a reason that it didn't already work like this, but I can't see one for now.