### PR TITLE
Adds bounds checking to large flock structures, plus ability to deconstruct flock stuff to clear space

### DIFF
--- a/code/datums/abilities/flock/flockmind.dm
+++ b/code/datums/abilities/flock/flockmind.dm
@@ -450,26 +450,37 @@
 	//furniture
 	if(istype(target, /obj/storage/closet/flock) || istype(target, /obj/stool/chair/comfy/flock) || istype(target, /obj/table/flock) || istype(target, /obj/machinery/light/flock))
 		F.flock.deconstruct_targets += target
+		F.flock.updateAnnotations()
 		return FALSE
 	//walls
 	else if(istype(target, /turf/simulated/wall/auto/feather))
 		F.flock.deconstruct_targets += target
+		F.flock.updateAnnotations()
+		return FALSE
+	//windows
+	else if(istype(target, /obj/window/feather))
+		F.flock.deconstruct_targets += target
+		F.flock.updateAnnotations()
 		return FALSE
 	else if(istype(target,/obj/structure/girder))
 		if(target?.material.mat_id == "gnesis")
 			F.flock.deconstruct_targets += target
+			F.flock.updateAnnotations()
 			return FALSE
 	//door
 	else if(istype(target, /obj/machinery/door/feather))
 		F.flock.deconstruct_targets += target
+		F.flock.updateAnnotations()
 		return FALSE
 	//structures
 	else if(istype(target, /obj/flock_structure))
 		F.flock.deconstruct_targets += target
+		F.flock.updateAnnotations()
 		return FALSE
 	//lattice/grille
 	else if(istype(target, /obj/lattice/flock) || istype(target, /obj/grille/flock))
 		F.flock.deconstruct_targets += target
+		F.flock.updateAnnotations()
 		return FALSE
 
 	return TRUE

--- a/code/datums/abilities/flock/flockmind.dm
+++ b/code/datums/abilities/flock/flockmind.dm
@@ -438,47 +438,39 @@
 /////////////////////////////////////////
 
 /datum/targetable/flockmindAbility/deconstruct
-	name = "Dissolve Structure"
-	desc = "Dissolve an existing flock structure, refunding some resources."
+	name = "Mark for Deconstruction"
+	desc = "Mark an existing flock structure for deconstruction, refunding some resources."
 	icon_state = "ping"
-	cooldown = 2 SECONDS
+	cooldown = 0.1 SECONDS
 
 /datum/targetable/flockmindAbility/deconstruct/cast(atom/target)
 	if(..())
 		return TRUE
-	//TODO animations for it to go all melty (maybe some sort of mask?)
-	if(istype(target, /turf/simulated/wall/auto/feather))
-		var/turf/simulated/wall/auto/feather/W = target
-		if(W)
-			W.destroy_resources()
-			return FALSE
-
-	if (isturf(target))
-		for(var/obj in target)
-			if(src.cast(obj))
-				return TRUE //pick the first thing on the turf that can be hit by this
+	var/mob/living/intangible/flock/F = holder.owner
+	//furniture
+	if(istype(target, /obj/storage/closet/flock) || istype(target, /obj/stool/chair/comfy/flock) || istype(target, /obj/table/flock) || istype(target, /obj/machinery/light/flock))
+		F.flock.deconstruct_targets += target
 		return FALSE
-	//precise targetting gets precise handling
-	if (isflockstructure(target))
-		var/mob/living/intangible/flock/F = holder.owner
-		var/obj/flock_structure/S = target
-		if(S && S.flock == F.flock)
-			S.deconstruct()
-			return FALSE
-	if(istype(target, /obj/machinery/door/feather))
-		var/obj/machinery/door/feather/D = target
-		if(D)
-			D.break_me_complitely()
-			return FALSE
-	if(istype(target, /obj/table/flock) || istype(target, /obj/stool/chair/comfy/flock) || istype(target, /obj/storage/closet/flock) || istype(target, /obj/machinery/light/flock))
-		//you a furniture, good job, you get melty
-		//spawn some gnesis on the floor?
-		qdel(target)
+	//walls
+	else if(istype(target, /turf/simulated/wall/auto/feather))
+		F.flock.deconstruct_targets += target
 		return FALSE
-	if(istype(target, /obj/lattice/flock) || istype(target, /obj/grille/flock))
-		qdel(target)
+	else if(istype(target,/obj/structure/girder))
+		if(target?.material.mat_id == "gnesis")
+			F.flock.deconstruct_targets += target
+			return FALSE
+	//door
+	else if(istype(target, /obj/machinery/door/feather))
+		F.flock.deconstruct_targets += target
 		return FALSE
-
+	//structures
+	else if(istype(target, /obj/flock_structure))
+		F.flock.deconstruct_targets += target
+		return FALSE
+	//lattice/grille
+	else if(istype(target, /obj/lattice/flock) || istype(target, /obj/grille/flock))
+		F.flock.deconstruct_targets += target
+		return FALSE
 
 	return TRUE
 

--- a/code/datums/abilities/flock/flockmind.dm
+++ b/code/datums/abilities/flock/flockmind.dm
@@ -391,10 +391,10 @@
 		boutput(holder.owner, "<span class='alert'>There is already a flock structure on this flocktile!</span>")
 		return 1
 
-	for (var/atom/O in T.contents)
+/*	for (var/atom/O in T.contents)
 		if (O.density && !isflock(O))
 			boutput(holder.owner, "<span class='alert'>That tile has something that blocks tealprint creation!</span>")
-			return 1
+			return 1 */
 
 	var/list/friendlyNames = list()
 	var/mob/living/intangible/flock/flockmind/F = holder.owner
@@ -415,7 +415,7 @@
 			break
 
 	if(structurewantedtype)
-		F.createstructure(structurewantedtype, initial(structurewantedtype.resourcecost))
+		return F.createstructure(structurewantedtype, initial(structurewantedtype.resourcecost))
 
 /////////////////////////////////////////
 
@@ -434,5 +434,53 @@
 	if(F)
 		var/datum/flock/flock = F.flock
 		flock?.ping(target, holder.owner)
+
+/////////////////////////////////////////
+
+/datum/targetable/flockmindAbility/deconstruct
+	name = "Dissolve Structure"
+	desc = "Dissolve an existing flock structure, refunding some resources."
+	icon_state = "ping"
+	cooldown = 2 SECONDS
+
+/datum/targetable/flockmindAbility/deconstruct/cast(atom/target)
+	if(..())
+		return TRUE
+	//TODO animations for it to go all melty (maybe some sort of mask?)
+	if(istype(target, /turf/simulated/wall/auto/feather))
+		var/turf/simulated/wall/auto/feather/W = target
+		if(W)
+			W.destroy_resources()
+			return FALSE
+
+	if (isturf(target))
+		for(var/obj in target)
+			if(src.cast(obj))
+				return TRUE //pick the first thing on the turf that can be hit by this
+		return FALSE
+	//precise targetting gets precise handling
+	if (isflockstructure(target))
+		var/mob/living/intangible/flock/F = holder.owner
+		var/obj/flock_structure/S = target
+		if(S && S.flock == F.flock)
+			S.deconstruct()
+			return FALSE
+	if(istype(target, /obj/machinery/door/feather))
+		var/obj/machinery/door/feather/D = target
+		if(D)
+			D.break_me_complitely()
+			return FALSE
+	if(istype(target, /obj/table/flock) || istype(target, /obj/stool/chair/comfy/flock) || istype(target, /obj/storage/closet/flock) || istype(target, /obj/machinery/light/flock))
+		//you a furniture, good job, you get melty
+		//spawn some gnesis on the floor?
+		qdel(target)
+		return FALSE
+	if(istype(target, /obj/lattice/flock) || istype(target, /obj/grille/flock))
+		qdel(target)
+		return FALSE
+
+
+	return TRUE
+
 
 

--- a/code/datums/abilities/flock/flockmind.dm
+++ b/code/datums/abilities/flock/flockmind.dm
@@ -474,9 +474,14 @@
 		return FALSE
 	//structures
 	else if(istype(target, /obj/flock_structure))
-		F.flock.deconstruct_targets += target
-		F.flock.updateAnnotations()
-		return FALSE
+		if(istype(target,/obj/flock_structure/ghost))
+			//do the tgui window instead
+			//this actually doesn't need bonus behaviour because the cancelbuild is on click, but will need to fix this if we change that in future
+			return TRUE
+		else
+			F.flock.deconstruct_targets += target
+			F.flock.updateAnnotations()
+			return FALSE
 	//lattice/grille
 	else if(istype(target, /obj/lattice/flock) || istype(target, /obj/grille/flock))
 		F.flock.deconstruct_targets += target

--- a/code/datums/abilities/flock/flockmind.dm
+++ b/code/datums/abilities/flock/flockmind.dm
@@ -392,18 +392,13 @@
 	var/turf/T = get_turf(holder.owner)
 	if(!istype(T, /turf/simulated/floor/feather))
 		boutput(holder.owner, "<span class='alert'>You aren't above a flocktile.</span>")//todo maybe make this flock themed?
-		return 1
+		return TRUE
 	if(locate(/obj/flock_structure/ghost) in T)
 		boutput(holder.owner, "<span class='alert'>A tealprint has already been scheduled here!</span>")
-		return 1
+		return TRUE
 	if(locate(/obj/flock_structure) in T)
 		boutput(holder.owner, "<span class='alert'>There is already a flock structure on this flocktile!</span>")
-		return 1
-
-/*	for (var/atom/O in T.contents)
-		if (O.density && !isflock(O))
-			boutput(holder.owner, "<span class='alert'>That tile has something that blocks tealprint creation!</span>")
-			return 1 */
+		return TRUE
 
 	var/list/friendlyNames = list()
 	var/mob/living/intangible/flock/flockmind/F = holder.owner
@@ -456,46 +451,20 @@
 	if(..())
 		return TRUE
 	var/mob/living/intangible/flock/F = holder.owner
-	//furniture
-	if(istype(target, /obj/storage/closet/flock) || istype(target, /obj/stool/chair/comfy/flock) || istype(target, /obj/table/flock) || istype(target, /obj/machinery/light/flock))
+	//special handling for building ghosts
+	if(istype(target,/obj/flock_structure/ghost))
+		//do the tgui window instead
+		//this actually doesn't need bonus behaviour because the cancelbuild is on click, but will need to fix this if we change that in future
+		return TRUE
+	else if(HAS_ATOM_PROPERTY(target,PROP_ATOM_FLOCK_THING)) //it's a thing we've converted, we can deconstruct it
 		F.flock.deconstruct_targets += target
 		F.flock.updateAnnotations()
 		return FALSE
-	//walls
-	else if(istype(target, /turf/simulated/wall/auto/feather))
-		F.flock.deconstruct_targets += target
-		F.flock.updateAnnotations()
-		return FALSE
-	//windows
-	else if(istype(target, /obj/window/feather))
-		F.flock.deconstruct_targets += target
-		F.flock.updateAnnotations()
-		return FALSE
-	else if(istype(target,/obj/structure/girder))
+	else if(istype(target,/obj/structure/girder)) //special handling for partially decon'd walls - gnesis mats means its ours
 		if(target?.material.mat_id == "gnesis")
 			F.flock.deconstruct_targets += target
 			F.flock.updateAnnotations()
 			return FALSE
-	//door
-	else if(istype(target, /obj/machinery/door/feather))
-		F.flock.deconstruct_targets += target
-		F.flock.updateAnnotations()
-		return FALSE
-	//structures
-	else if(istype(target, /obj/flock_structure))
-		if(istype(target,/obj/flock_structure/ghost))
-			//do the tgui window instead
-			//this actually doesn't need bonus behaviour because the cancelbuild is on click, but will need to fix this if we change that in future
-			return TRUE
-		else
-			F.flock.deconstruct_targets += target
-			F.flock.updateAnnotations()
-			return FALSE
-	//lattice/grille
-	else if(istype(target, /obj/lattice/flock) || istype(target, /obj/grille/flock))
-		F.flock.deconstruct_targets += target
-		F.flock.updateAnnotations()
-		return FALSE
 
 	return TRUE
 

--- a/code/datums/flock/flock.dm
+++ b/code/datums/flock/flock.dm
@@ -373,6 +373,21 @@
 			src.annotations[B] = I
 		// add key to list
 		valid_keys |= B
+	//highlight deconstruction targets
+	for(var/obj/D in src.deconstruct_targets)
+		if(!(D in src.annotations))
+			// create a new image
+			I = image('icons/misc/featherzone.dmi', D, "hazard")
+			I.blend_mode = BLEND_ADD
+			I.pixel_y = 16
+			I.plane = PLANE_ABOVE_LIGHTING
+			I.appearance_flags = RESET_COLOR | RESET_ALPHA | RESET_TRANSFORM
+			// add to subscribers for annotations
+			images_to_add |= I
+			src.annotations[D] = I
+		// add key to list
+		if(!D.disposed)
+			valid_keys |= D
 	var/list/to_remove = list()
 	for(var/atom/key in src.annotations)
 		if(!(key in valid_keys))

--- a/code/datums/flock/flock.dm
+++ b/code/datums/flock/flock.dm
@@ -374,7 +374,7 @@
 		// add key to list
 		valid_keys |= B
 	//highlight deconstruction targets
-	for(var/obj/D in src.deconstruct_targets)
+	for(var/atom/D in src.deconstruct_targets)
 		if(!(D in src.annotations))
 			// create a new image
 			I = image('icons/misc/featherzone.dmi', D, "hazard")
@@ -568,6 +568,14 @@
 
 	for(var/datum/unlockable_flock_structure/ufs as anything in src.unlockableStructures)
 		ufs.process()
+
+	//handle deconstruct targets being destroyed by other means
+	var/list/toRemove = list()
+	for(var/atom/S in src.deconstruct_targets)
+		if(S.disposed)
+			toRemove += S
+	for(var/atom/S in toRemove)
+		src.deconstruct_targets -= S
 
 /datum/flock/proc/convert_turf(var/turf/T, var/converterName)
 	src.unreserveTurf(converterName)

--- a/code/datums/flock/flock.dm
+++ b/code/datums/flock/flock.dm
@@ -572,12 +572,9 @@
 		ufs.process()
 
 	//handle deconstruct targets being destroyed by other means
-	var/list/toRemove = list()
 	for(var/atom/S in src.deconstruct_targets)
 		if(S.disposed)
-			toRemove += S
-	for(var/atom/S in toRemove)
-		src.deconstruct_targets -= S
+			src.deconstruct_targets -= S
 
 /datum/flock/proc/convert_turf(var/turf/T, var/converterName)
 	src.unreserveTurf(converterName)

--- a/code/datums/flock/flock.dm
+++ b/code/datums/flock/flock.dm
@@ -252,6 +252,7 @@
 	var/const/duration = 5 SECOND
 	var/end_time = -1
 	var/obj/dummy = null
+	var/outline_color = "#00ff9d"
 
 	Initialize()
 		if (!ismovable(parent) && !isturf(parent))
@@ -272,7 +273,7 @@
 		dummy.icon_state = target.icon_state
 		target.render_target = ref(parent)
 		dummy.render_source = target.render_target
-		dummy.add_filter("outline", 1, outline_filter(size=1,color="#00ff9d"))
+		dummy.add_filter("outline", 1, outline_filter(size=1,color=src.outline_color))
 		target.vis_contents += dummy
 
 		play_animation()

--- a/code/datums/flock/flock.dm
+++ b/code/datums/flock/flock.dm
@@ -10,6 +10,7 @@
 	var/list/all_owned_tiles = list()
 	var/list/busy_tiles = list()
 	var/list/priority_tiles = list()
+	var/list/deconstruct_targets = list()
 	var/list/traces = list()
 	var/list/units = list()
 	var/list/enemies = list()

--- a/code/datums/flock/flock.dm
+++ b/code/datums/flock/flock.dm
@@ -647,8 +647,9 @@
 			animate_flock_convert_complete(T)
 
 	if(istype(T, /turf/simulated/wall))
-		T.ReplaceWith("/turf/simulated/wall/auto/feather", 0)
+		var/turf/converted_wall = T.ReplaceWith("/turf/simulated/wall/auto/feather", 0)
 		animate_flock_convert_complete(T)
+		APPLY_ATOM_PROPERTY(converted_wall, PROP_ATOM_FLOCK_THING, "flock_convert_turf")
 
 	// regular and flock lattices
 	var/obj/lattice/lat = locate(/obj/lattice) in T
@@ -666,7 +667,8 @@
 	if(istype(T, /turf/space))
 		var/obj/lattice/flock/FL = locate(/obj/lattice/flock) in T
 		if(!FL)
-			new /obj/lattice/flock(T)
+			FL = new /obj/lattice/flock(T) //may as well reuse the var
+			APPLY_ATOM_PROPERTY(FL, PROP_ATOM_FLOCK_THING, "flock_convert_turf")
 	else // don't do this stuff if the turf is space, it fucks it up more
 		T.RL_Cleanup()
 		T.RL_LumR = RL_LumR

--- a/code/datums/flock/flockunlockable.dm
+++ b/code/datums/flock/flockunlockable.dm
@@ -34,7 +34,7 @@ ABSTRACT_TYPE(/datum/unlockable_flock_structure)
 	structType = /obj/flock_structure/relay
 
 	check_unlocked()
-		return src.my_flock.total_compute() > 1000 || src.my_flock.hasAchieved("cheatmode")
+		return src.my_flock.total_compute() > 1000 || src.my_flock.hasAchieved("all_structures")
 
 /datum/unlockable_flock_structure/collector
 	structType = /obj/flock_structure/collector

--- a/code/datums/flock/flockunlockable.dm
+++ b/code/datums/flock/flockunlockable.dm
@@ -34,7 +34,7 @@ ABSTRACT_TYPE(/datum/unlockable_flock_structure)
 	structType = /obj/flock_structure/relay
 
 	check_unlocked()
-		return src.my_flock.total_compute() > 1000
+		return src.my_flock.total_compute() > 1000 || src.my_flock.hasAchieved("cheatmode")
 
 /datum/unlockable_flock_structure/collector
 	structType = /obj/flock_structure/collector

--- a/code/mob/living/critter/ai/flock/flockdrone.dm
+++ b/code/mob/living/critter/ai/flock/flockdrone.dm
@@ -24,6 +24,7 @@
 	transition_tasks += holder.get_instance(/datum/aiTask/sequence/goalbased/harvest, list(holder, src))
 	transition_tasks += holder.get_instance(/datum/aiTask/timed/targeted/flockdrone_shoot, list(holder, src))
 	transition_tasks += holder.get_instance(/datum/aiTask/sequence/goalbased/flockdrone_capture, list(holder, src))
+	transition_tasks += holder.get_instance(/datum/aiTask/sequence/goalbased/deconstruct, list(holder, src))
 	transition_tasks += holder.get_instance(/datum/aiTask/timed/wander, list(holder, src))
 
 /datum/aiTask/prioritizer/flock/drone/on_reset()

--- a/code/mob/living/critter/ai/flock/flocktasks.dm
+++ b/code/mob/living/critter/ai/flock/flocktasks.dm
@@ -957,9 +957,10 @@ butcher
 		return TRUE
 
 /datum/aiTask/succeedable/deconstruct/succeeded()
-	. = (!actions.hasAction(holder.owner, "flock_deconstruct")) // for whatever reason, the required action has stopped
-	var/mob/living/critter/flock/drone/F = holder.owner
-	F?.flock?.deconstruct_targets -= holder.target
+	. = (!actions.hasAction(holder.owner, "flock_decon")) // for whatever reason, the required action has stopped
+	if(.)
+		var/mob/living/critter/flock/drone/F = holder.owner
+		F?.flock?.deconstruct_targets -= holder.target
 
 /datum/aiTask/succeedable/deconstruct/on_tick()
 	if(!has_started)
@@ -970,7 +971,6 @@ butcher
 				F.set_a_intent(INTENT_HARM)
 				holder.owner.set_dir(get_dir(holder.owner, holder.target))
 				F.hand_attack(T)
-
 				has_started = TRUE
 
 /datum/aiTask/succeedable/deconstruct/on_reset()

--- a/code/mob/living/critter/ai/flock/flocktasks.dm
+++ b/code/mob/living/critter/ai/flock/flocktasks.dm
@@ -916,6 +916,7 @@ butcher
 /datum/aiTask/sequence/goalbased/deconstruct
 	name = "deconstructing"
 	weight = 8
+	can_be_adjacent_to_target = TRUE
 
 /datum/aiTask/sequence/goalbased/deconstruct/New(parentHolder, transTask)
 	..(parentHolder, transTask)

--- a/code/mob/living/critter/ai/flock/flocktasks.dm
+++ b/code/mob/living/critter/ai/flock/flocktasks.dm
@@ -907,3 +907,71 @@ butcher
 
 /datum/aiTask/succeedable/butcher/on_reset()
 	has_started = FALSE
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////
+// DECONTSTRUCT GOAL
+// targets: flock deconstruction targets
+// precondition: 10 resources
+/datum/aiTask/sequence/goalbased/deconstruct
+	name = "deconstructing"
+	weight = 8
+
+/datum/aiTask/sequence/goalbased/deconstruct/New(parentHolder, transTask)
+	..(parentHolder, transTask)
+	add_task(holder.get_instance(/datum/aiTask/succeedable/deconstruct, list(holder)))
+
+/datum/aiTask/sequence/goalbased/deconstruct/precondition()
+	. = FALSE
+	var/mob/living/critter/flock/drone/F = holder.owner
+	if(length(F?.flock?.deconstruct_targets))
+		. = TRUE
+
+/datum/aiTask/sequence/goalbased/deconstruct/on_reset()
+	var/mob/living/critter/flock/drone/F = holder.owner
+	if(F)
+		F.active_hand = 2 // nanite spray
+		F.set_a_intent(INTENT_HARM)
+		F.hud?.update_intent()
+		F.hud?.update_hands() // for observers
+
+/datum/aiTask/sequence/goalbased/deconstruct/get_targets()
+	var/mob/living/critter/flock/drone/F = holder.owner
+	. = list()
+	for(var/obj/S in F?.flock?.deconstruct_targets)
+		if(IN_RANGE(S,holder.owner,max_dist))
+			// if we can get a valid path to the target, include it for consideration
+			. += S
+	. = get_path_to(holder.owner, ., max_dist*2, 1)
+
+////////
+
+/datum/aiTask/succeedable/deconstruct
+	name = "deconstruct subtask"
+	var/has_started = FALSE
+
+/datum/aiTask/succeedable/deconstruct/failed()
+	var/mob/living/critter/flock/drone/F = holder.owner
+	var/obj/T = holder.target
+	if(!F || !T || BOUNDS_DIST(T, F) > 0)
+		return TRUE
+
+/datum/aiTask/succeedable/deconstruct/succeeded()
+	. = (!actions.hasAction(holder.owner, "flock_deconstruct")) // for whatever reason, the required action has stopped
+	var/mob/living/critter/flock/drone/F = holder.owner
+	F?.flock?.deconstruct_targets -= holder.target
+
+/datum/aiTask/succeedable/deconstruct/on_tick()
+	if(!has_started)
+		var/mob/living/critter/flock/drone/F = holder.owner
+		var/obj/T = holder.target
+		if(F && T && BOUNDS_DIST(holder.owner, holder.target) == FALSE)
+			if(F.set_hand(2)) // nanite spray
+				F.set_a_intent(INTENT_HARM)
+				holder.owner.set_dir(get_dir(holder.owner, holder.target))
+				F.hand_attack(T)
+
+				has_started = TRUE
+
+/datum/aiTask/succeedable/deconstruct/on_reset()
+	has_started = FALSE

--- a/code/mob/living/critter/ai/flock/flocktasks.dm
+++ b/code/mob/living/critter/ai/flock/flocktasks.dm
@@ -939,7 +939,7 @@ butcher
 /datum/aiTask/sequence/goalbased/deconstruct/get_targets()
 	var/mob/living/critter/flock/drone/F = holder.owner
 	. = list()
-	for(var/obj/S in F?.flock?.deconstruct_targets)
+	for(var/atom/S in F?.flock?.deconstruct_targets)
 		if(IN_RANGE(S,holder.owner,max_dist))
 			// if we can get a valid path to the target, include it for consideration
 			. += S
@@ -953,7 +953,7 @@ butcher
 
 /datum/aiTask/succeedable/deconstruct/failed()
 	var/mob/living/critter/flock/drone/F = holder.owner
-	var/obj/T = holder.target
+	var/atom/T = holder.target
 	if(!F || !T || BOUNDS_DIST(T, F) > 0)
 		return TRUE
 
@@ -966,7 +966,7 @@ butcher
 /datum/aiTask/succeedable/deconstruct/on_tick()
 	if(!has_started)
 		var/mob/living/critter/flock/drone/F = holder.owner
-		var/obj/T = holder.target
+		var/atom/T = holder.target
 		if(F && T && BOUNDS_DIST(holder.owner, holder.target) == FALSE)
 			if(F.set_hand(2)) // nanite spray
 				F.set_a_intent(INTENT_HARM)

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -804,6 +804,9 @@
 		//walls
 		else if(istype(target, /turf/simulated/wall/auto/feather))
 			actions.start(new /datum/action/bar/flock_decon(target), user)
+		//windows
+		else if(istype(target, /obj/window/feather))
+			actions.start(new /datum/action/bar/flock_decon(target), user)
 		else if(istype(target,/obj/structure/girder))
 			if(target?.material.mat_id == "gnesis")
 				actions.start(new /datum/action/bar/flock_decon(target), user)

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -768,8 +768,8 @@
 			return
 
 	// CONVERT TURF
-	if(!isturf(target) && !(istype(target, /obj/storage/closet/flock) || istype(target, /obj/table/flock) || istype(target, /obj/structure/girder) || istype(target, /obj/machinery/door/feather) || istype(target, /obj/flock_structure/ghost)))
-		target = get_turf(target)
+	//if(!isturf(target) && !(istype(target, /obj/storage/closet/flock) || istype(target, /obj/table/flock) || istype(target, /obj/structure/girder) || istype(target, /obj/machinery/door/feather) || istype(target, /obj/flock_structure/ghost)))
+	//	target = get_turf(target)
 
 	if(istype(target, /turf) && !istype(target, /turf/simulated) && !istype(target, /turf/space))
 		boutput(user, "<span class='alert'>Something about this structure prevents it from being assimilated.</span>")

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -798,26 +798,26 @@
 		if(istype(target, /turf))
 			actions.start(new/datum/action/bar/flock_convert(target), user)
 	if(user.a_intent == INTENT_HARM)
-		switch (target.type)
-			if(/obj/table/flock, /obj/table/flock/auto)
+		//furniture
+		if(istype(target, /obj/storage/closet/flock) || istype(target, /obj/stool/chair/comfy/flock) || istype(target, /obj/table/flock) || istype(target, /obj/machinery/light/flock))
+			actions.start(new /datum/action/bar/flock_decon(target), user)
+		//walls
+		else if(istype(target, /turf/simulated/wall/auto/feather))
+			actions.start(new /datum/action/bar/flock_decon(target), user)
+		else if(istype(target,/obj/structure/girder))
+			if(target?.material.mat_id == "gnesis")
 				actions.start(new /datum/action/bar/flock_decon(target), user)
-			if(/obj/storage/closet/flock)
-				//soap
-				actions.start(new /datum/action/bar/flock_decon(target), user)
-			if(/turf/simulated/wall/auto/feather)
-				actions.start(new /datum/action/bar/flock_decon(target), user)
-			if(/obj/structure/girder)
-				if(target?.material.mat_id == "gnesis")
-					var/atom/A = new /obj/item/sheet(get_turf(target))
-					if (target.material)
-						A.setMaterial(target.material)
-						qdel(target)
-				else
-					return
-			if(/obj/machinery/door/feather)
-				actions.start(new /datum/action/bar/flock_decon(target), user)
-			else
-				..()
+		//door
+		else if(istype(target, /obj/machinery/door/feather))
+			actions.start(new /datum/action/bar/flock_decon(target), user)
+		//structures
+		else if(istype(target, /obj/flock_structure))
+			actions.start(new /datum/action/bar/flock_decon(target), user)
+		//lattice/grille
+		else if(istype(target, /obj/lattice/flock) || istype(target, /obj/grille/flock))
+			actions.start(new /datum/action/bar/flock_decon(target), user)
+		else
+			..()
 //help intent actions
 	else if(user.a_intent == INTENT_HELP)
 		switch(target.type)//making this into switches for easy of expansion later

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -768,8 +768,8 @@
 			return
 
 	// CONVERT TURF
-	//if(!isturf(target) && !(istype(target, /obj/storage/closet/flock) || istype(target, /obj/table/flock) || istype(target, /obj/structure/girder) || istype(target, /obj/machinery/door/feather) || istype(target, /obj/flock_structure/ghost)))
-	//	target = get_turf(target)
+	if(!isturf(target) && !HAS_ATOM_PROPERTY(target,PROP_ATOM_FLOCK_THING))
+		target = get_turf(target)
 
 	if(istype(target, /turf) && !istype(target, /turf/simulated) && !istype(target, /turf/space))
 		boutput(user, "<span class='alert'>Something about this structure prevents it from being assimilated.</span>")
@@ -799,26 +799,11 @@
 			actions.start(new/datum/action/bar/flock_convert(target), user)
 	if(user.a_intent == INTENT_HARM)
 		//furniture
-		if(istype(target, /obj/storage/closet/flock) || istype(target, /obj/stool/chair/comfy/flock) || istype(target, /obj/table/flock) || istype(target, /obj/machinery/light/flock))
+		if(HAS_ATOM_PROPERTY(target,PROP_ATOM_FLOCK_THING))
 			actions.start(new /datum/action/bar/flock_decon(target), user)
-		//walls
-		else if(istype(target, /turf/simulated/wall/auto/feather))
-			actions.start(new /datum/action/bar/flock_decon(target), user)
-		//windows
-		else if(istype(target, /obj/window/feather))
-			actions.start(new /datum/action/bar/flock_decon(target), user)
-		else if(istype(target,/obj/structure/girder))
+		else if(istype(target,/obj/structure/girder)) //special handling for partially deconstructed walls
 			if(target?.material.mat_id == "gnesis")
 				actions.start(new /datum/action/bar/flock_decon(target), user)
-		//door
-		else if(istype(target, /obj/machinery/door/feather))
-			actions.start(new /datum/action/bar/flock_decon(target), user)
-		//structures
-		else if(istype(target, /obj/flock_structure))
-			actions.start(new /datum/action/bar/flock_decon(target), user)
-		//lattice/grille
-		else if(istype(target, /obj/lattice/flock) || istype(target, /obj/grille/flock))
-			actions.start(new /datum/action/bar/flock_decon(target), user)
 		else
 			..()
 //help intent actions

--- a/code/mob/living/critter/flockcritter_parent.dm
+++ b/code/mob/living/critter/flockcritter_parent.dm
@@ -488,35 +488,53 @@
 
 	onEnd()
 		..()
-		switch(target.type)
-			if(/obj/storage/closet/flock)
-				var/turf/T = get_turf(target)
-				var/obj/storage/closet/flock/c = target
-				playsound(T, "sound/impact_sounds/Glass_Shatter_3.ogg", 25, 1)
-				var/obj/item/raw_material/shard/S = new /obj/item/raw_material/shard
-				S.set_loc(T)
-				S.setMaterial(getMaterial("gnesisglass"))
-				c.dump_contents()
-				qdel(target)
-				target = null
-			if(/turf/simulated/wall/auto/feather)
-				var/turf/simulated/wall/auto/feather/f = target
-				f.destroy_resources()
-			if(/obj/machinery/door/feather)
-				var/turf/T = get_turf(target)
-				playsound(T, "sound/impact_sounds/Glass_Shatter_3.ogg", 25, 1)
-				var/obj/item/raw_material/shard/S = new /obj/item/raw_material/shard
-				S.set_loc(T)
-				S.setMaterial(getMaterial("gnesisglass"))
-				S = new /obj/item/raw_material/shard
-				S.set_loc(T)
-				S.setMaterial(getMaterial("gnesis"))
-				qdel(target)
-				target = null
-			if(/obj/table/flock, /obj/table/flock/auto)
-				var/obj/table/flock/f = target
-				playsound(f, "sound/items/Deconstruct.ogg", 50, 1)
+		//good news, switch is awful, we're doing an if chain now
+		if(istype(target, /obj/storage/closet/flock))
+			var/turf/T = get_turf(target)
+			var/obj/storage/closet/flock/c = target
+			playsound(T, "sound/impact_sounds/Glass_Shatter_3.ogg", 25, 1)
+			var/obj/item/raw_material/shard/S = new /obj/item/raw_material/shard
+			S.set_loc(T)
+			S.setMaterial(getMaterial("gnesisglass"))
+			c.dump_contents()
+			qdel(target)
+			target = null
+		if(istype(target, /turf/simulated/wall/auto/feather))
+			var/turf/simulated/wall/auto/feather/f = target
+			f.destroy_resources()
+		if(istype(target, /obj/machinery/door/feather))
+			var/turf/T = get_turf(target)
+			playsound(T, "sound/impact_sounds/Glass_Shatter_3.ogg", 25, 1)
+			var/obj/item/raw_material/shard/S = new /obj/item/raw_material/shard
+			S.set_loc(T)
+			S.setMaterial(getMaterial("gnesisglass"))
+			S = new /obj/item/raw_material/shard
+			S.set_loc(T)
+			S.setMaterial(getMaterial("gnesis"))
+			qdel(target)
+			target = null
+		if(istype(target, /obj/table/flock))
+			var/obj/table/flock/f = target
+			playsound(f, "sound/items/Deconstruct.ogg", 50, 1)
+			f.deconstruct()
+		if(istype(target, /obj/flock_structure))
+			if(istype(target,/obj/flock_structure/ghost))
+				var/obj/flock_structure/ghost/f = target
+				f.cancelBuild()
+			else
+				var/obj/flock_structure/f = target
 				f.deconstruct()
+		if(istype(target, /obj/stool/chair/comfy/flock))
+			var/obj/stool/chair/comfy/flock/c = target
+			c.deconstruct()
+		if(istype(target, /obj/machinery/light/flock))
+			var/turf/T = get_turf(target)
+			playsound(T, "sound/impact_sounds/Glass_Shatter_3.ogg", 25, 1)
+			qdel(target)
+		if(istype(target, /obj/lattice/flock))
+			qdel(target)
+		if(istype(target, /obj/grille/flock))
+			qdel(target)
 //
 //deposit action
 //

--- a/code/mob/living/critter/flockcritter_parent.dm
+++ b/code/mob/living/critter/flockcritter_parent.dm
@@ -535,6 +535,20 @@
 			qdel(target)
 		if(istype(target, /obj/grille/flock))
 			qdel(target)
+		if(istype(target, /obj/window/feather))
+			var/obj/window/the_window = target
+			//copied wholesale from the /obj/window deconstruction code
+			var/obj/item/sheet/A = new /obj/item/sheet(get_turf(the_window))
+			if(the_window.material)
+				A.setMaterial(the_window.material)
+			else
+				var/datum/material/M = getMaterial("glass")
+				A.setMaterial(M)
+			if(!(the_window.dir in cardinal)) // full window takes two sheets to make
+				A.amount += 1
+			if(the_window.reinforcement)
+				A.set_reinforcement(the_window.reinforcement)
+			qdel(the_window)
 //
 //deposit action
 //

--- a/code/mob/living/critter/flockcritter_parent.dm
+++ b/code/mob/living/critter/flockcritter_parent.dm
@@ -501,7 +501,9 @@
 			target = null
 		if(istype(target, /turf/simulated/wall/auto/feather))
 			var/turf/simulated/wall/auto/feather/f = target
+			var/turf/T = get_turf(target)
 			f.destroy_resources()
+			make_cleanable( /obj/decal/cleanable/flockdrone_debris/fluid,T)
 		if(istype(target, /obj/machinery/door/feather))
 			var/turf/T = get_turf(target)
 			playsound(T, "sound/impact_sounds/Glass_Shatter_3.ogg", 25, 1)
@@ -518,17 +520,14 @@
 			playsound(f, "sound/items/Deconstruct.ogg", 50, 1)
 			f.deconstruct()
 		if(istype(target, /obj/flock_structure))
-			if(istype(target,/obj/flock_structure/ghost))
-				var/obj/flock_structure/ghost/f = target
-				f.cancelBuild()
-			else
-				var/obj/flock_structure/f = target
-				f.deconstruct()
+			var/obj/flock_structure/f = target
+			f.deconstruct()
 		if(istype(target, /obj/stool/chair/comfy/flock))
 			var/obj/stool/chair/comfy/flock/c = target
 			c.deconstruct()
 		if(istype(target, /obj/machinery/light/flock))
 			var/turf/T = get_turf(target)
+			make_cleanable( /obj/decal/cleanable/flockdrone_debris/fluid,T)
 			playsound(T, "sound/impact_sounds/Glass_Shatter_3.ogg", 25, 1)
 			qdel(target)
 		if(istype(target, /obj/lattice/flock))

--- a/code/mob/living/intangible/flock/flockmind.dm
+++ b/code/mob/living/intangible/flock/flockmind.dm
@@ -91,6 +91,7 @@
 	src.addAbility(/datum/targetable/flockmindAbility/radioStun)
 	src.addAbility(/datum/targetable/flockmindAbility/directSay)
 	src.addAbility(/datum/targetable/flockmindAbility/createStructure)
+	src.addAbility(/datum/targetable/flockmindAbility/deconstruct)
 
 /mob/living/intangible/flock/flockmind/death(gibbed)
 	if(src.client)

--- a/code/obj/flock/structure/flock_structure_ghost.dm
+++ b/code/obj/flock/structure/flock_structure_ghost.dm
@@ -33,10 +33,37 @@
 	else
 		flock_speak(null, "ERROR: No Structure Tealprint Assigned, Deleting", flock)
 		qdel(src) //no exist if building null
+		return
+
+	//bounds checking goes here
+	var/blocked = FALSE
+	for(var/turf/T in src.locs)
+		if(flock_is_blocked_turf(T))
+			blocked = TRUE
+			T.AddComponent(/datum/component/flock_ping/obstruction)
+
+	if(blocked)
+		qdel(src)
+		flock_speak(null, "ERROR: Build area is blocked by an obstruction.", flock)
+		return
+
+/obj/flock_structure/ghost/proc/flock_is_blocked_turf(var/turf/T)
+	// nicked from is_blocked_turf
+	if (!T) return 0
+	if(T.density) return 1
+	for(var/atom/A in T)
+		if(A?.density && !isflock(A))//ignores flockdrones/flockbits
+			return 1
+	return 0
+
 
 /obj/flock_structure/ghost/Click(location, control, params)
 	if (("alt" in params2list(params)) || !istype(usr, /mob/living/intangible/flock/flockmind))
 		return ..()
+	if (tgui_alert(usr, "Cancel tealprint construction?", "Tealprint", list("Yes", "No")) == "Yes")
+		cancelBuild()
+
+/obj/flock_structure/ghost/deconstruct()
 	if (tgui_alert(usr, "Cancel tealprint construction?", "Tealprint", list("Yes", "No")) == "Yes")
 		cancelBuild()
 
@@ -66,3 +93,9 @@
 	flock_speak(src, "Tealprint derealizing", flock)
 	playsound(src, 'sound/misc/flockmind/flockdrone_door_deny.ogg', 50, 1)
 	qdel(src)
+
+
+////////////////////////////////////////////////////////////////////////
+
+/datum/component/flock_ping/obstruction
+	outline_color = "#f51e1e"

--- a/code/obj/flock/structure/flock_structure_ghost.dm
+++ b/code/obj/flock/structure/flock_structure_ghost.dm
@@ -98,4 +98,4 @@
 ////////////////////////////////////////////////////////////////////////
 
 /datum/component/flock_ping/obstruction
-	outline_color = "#f51e1e"
+	outline_color = "#910707"

--- a/code/obj/flock/structure/flock_structure_ghost.dm
+++ b/code/obj/flock/structure/flock_structure_ghost.dm
@@ -64,8 +64,7 @@
 		cancelBuild()
 
 /obj/flock_structure/ghost/deconstruct()
-	if (tgui_alert(usr, "Cancel tealprint construction?", "Tealprint", list("Yes", "No")) == "Yes")
-		cancelBuild()
+	cancelBuild()
 
 /obj/flock_structure/ghost/process()
 	if(currentmats > goal)

--- a/code/obj/flock/structure/flock_structure_parent.dm
+++ b/code/obj/flock/structure/flock_structure_parent.dm
@@ -12,7 +12,7 @@
 	var/time_started = 0
 	var/build_time = 6 // in seconds
 	var/health = 30 // fragile little thing
-	var/health_max
+	var/health_max = 30
 	var/bruteVuln = 1.2
 	/// very flame-retardant
 	var/fireVuln = 0.2
@@ -128,6 +128,17 @@
 	if(src.health <= 0)
 		src.gib()
 
+/obj/flock_structure/proc/deconstruct()
+	//you can have half your resources back
+	visible_message("<span class='alert'>[src.name] suddenly dissolves!</span>")
+	var/refund = round((src.health/src.health_max) * 0.5 * src.resourcecost) //this is floor(), depsite the name
+	if(refund >= 1)
+		var/obj/item/flockcache/cache = new(get_turf(src))
+		cache.resources = refund
+	src.flock?.removeDrone(src)
+	qdel(src)
+
+
 /obj/flock_structure/proc/gib(atom/location)
 	// no parent calling, we're going to completely override this
 	if (!location)
@@ -195,7 +206,7 @@
 
 /obj/flock_structure/ex_act(severity)
 	src.report_attack()
-	
+
 	var/damage = 0
 	var/damage_mult = 1
 	switch(severity)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [FEATURE][BUGFIX] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds bounds checking to the placement of flock structures with highlighting of the offending blockers

Adds a new ability: "Mark for Deconstruct" which sets existing flock structures (including walls/furniture/doors) to be targeted for deconstruction by nearby drones, refunding some resources where appropriate. Because good luck placing a 5x5 structure on basically any map.

Could use a little polish, namely: 

- Icon for marked as deconstruct should be different to the enemy one
- need an icon for the abilityHolder -currently reusing ping


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #162 