### PR TITLE
Add cost to floorrunning

### DIFF
--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -425,24 +425,6 @@
 
 /mob/living/critter/flock/drone/Move(NewLoc, direct)
 	if(!canmove) return
-	/*
-	if (isfeathertile(NewLoc) && src.client?.check_key(KEY_RUN) && src.resources)
-		if (istype(NewLoc, /turf/simulated/floor/feather))
-			var/turf/simulated/floor/feather/floor = NewLoc
-			if (!floor.broken)
-				src.resources--
-		else
-			src.resources--
-		if (!src.resources)
-			src.set_dir(get_dir(src, NewLoc))
-			src.set_loc(NewLoc)
-			src.end_floorrunning()
-			if (istype(NewLoc, /turf/simulated/floor/feather))
-				var/turf/simulated/floor/feather/floor = NewLoc
-				if (floor.on && !floor.connected)
-					floor.off()
-			return
-	*/
 	if(floorrunning)
 		// do our custom MOVE THROUGH ANYTHING stuff
 		// copypasted from intangible.dm

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -322,6 +322,14 @@
 /mob/living/critter/flock/drone/Life(datum/controller/process/mobs/parent)
 	if (..(parent))
 		return 1
+	if (src.floorrunning && src.resources)
+		src.resources--
+		if (!src.resources)
+			src.end_floorrunning()
+			if (istype(src.loc, /turf/simulated/floor/feather))
+				var/turf/simulated/floor/feather/floor = src.loc
+				if (floor.on && !floor.connected)
+					floor.off()
 	var/obj/item/I = absorber.item
 
 	if(I)
@@ -376,7 +384,7 @@
 				src.antigrab_counter = 0
 	else
 		src.antigrab_counter = 0
-	if(keys & KEY_RUN)
+	if(keys & KEY_RUN && src.resources)
 		if(!src.floorrunning && isfeathertile(src.loc))
 			if(istype(src.loc, /turf/simulated/floor/feather))
 				var/turf/simulated/floor/feather/floor = src.loc
@@ -417,7 +425,24 @@
 
 /mob/living/critter/flock/drone/Move(NewLoc, direct)
 	if(!canmove) return
-
+	/*
+	if (isfeathertile(NewLoc) && src.client?.check_key(KEY_RUN) && src.resources)
+		if (istype(NewLoc, /turf/simulated/floor/feather))
+			var/turf/simulated/floor/feather/floor = NewLoc
+			if (!floor.broken)
+				src.resources--
+		else
+			src.resources--
+		if (!src.resources)
+			src.set_dir(get_dir(src, NewLoc))
+			src.set_loc(NewLoc)
+			src.end_floorrunning()
+			if (istype(NewLoc, /turf/simulated/floor/feather))
+				var/turf/simulated/floor/feather/floor = NewLoc
+				if (floor.on && !floor.connected)
+					floor.off()
+			return
+	*/
 	if(floorrunning)
 		// do our custom MOVE THROUGH ANYTHING stuff
 		// copypasted from intangible.dm

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -322,9 +322,9 @@
 /mob/living/critter/flock/drone/Life(datum/controller/process/mobs/parent)
 	if (..(parent))
 		return 1
-	if (src.floorrunning && src.resources)
+	if (src.floorrunning && src.resources >= 1)
 		src.resources--
-		if (!src.resources)
+		if (src.resources < 1)
 			src.end_floorrunning()
 			if (istype(src.loc, /turf/simulated/floor/feather))
 				var/turf/simulated/floor/feather/floor = src.loc
@@ -384,7 +384,7 @@
 				src.antigrab_counter = 0
 	else
 		src.antigrab_counter = 0
-	if(keys & KEY_RUN && src.resources)
+	if(keys & KEY_RUN && src.resources >= 1)
 		if(!src.floorrunning && isfeathertile(src.loc))
 			if(istype(src.loc, /turf/simulated/floor/feather))
 				var/turf/simulated/floor/feather/floor = src.loc

--- a/code/turf/turf_flock.dm
+++ b/code/turf/turf_flock.dm
@@ -95,12 +95,12 @@
 	..()
 	if(!istype(F) || !oldloc)
 		return
-	if(F.client && F.client.check_key(KEY_RUN) && !broken && !F.floorrunning && F.resources)
+	if(F.client && F.client.check_key(KEY_RUN) && !broken && !F.floorrunning && F.resources >= 1)
 		F.start_floorrunning()
 
 	if(F.floorrunning && !broken)
 		F.resources--
-		if (!F.resources)
+		if (F.resources < 1)
 			F.end_floorrunning()
 		else if(!on)
 			on()
@@ -396,12 +396,12 @@ turf/simulated/floor/feather/proc/bfs(turf/start)//breadth first search, made by
 	..()
 	if(!istype(F) || !oldloc)
 		return
-	if(F.client && F.client.check_key(KEY_RUN) && !F.floorrunning && F.resources)
+	if(F.client && F.client.check_key(KEY_RUN) && !F.floorrunning && F.resources >= 1)
 		F.start_floorrunning()
 
 	if(F.floorrunning)
 		F.resources--
-		if (!F.resources)
+		if (F.resources < 1)
 			F.end_floorrunning()
 
 /turf/simulated/wall/auto/feather/Exited(var/mob/living/critter/flock/drone/F, atom/newloc)

--- a/code/turf/turf_flock.dm
+++ b/code/turf/turf_flock.dm
@@ -95,10 +95,14 @@
 	..()
 	if(!istype(F) || !oldloc)
 		return
-	if(F.client && F.client.check_key(KEY_RUN) && !broken && !F.floorrunning)
+	if(F.client && F.client.check_key(KEY_RUN) && !broken && !F.floorrunning && F.resources)
 		F.start_floorrunning()
+
 	if(F.floorrunning && !broken)
-		if(!on)
+		F.resources--
+		if (!F.resources)
+			F.end_floorrunning()
+		else if(!on)
 			on()
 
 /turf/simulated/floor/feather/Exited(var/mob/living/critter/flock/drone/F, atom/newloc)
@@ -392,8 +396,13 @@ turf/simulated/floor/feather/proc/bfs(turf/start)//breadth first search, made by
 	..()
 	if(!istype(F) || !oldloc)
 		return
-	if(F.client && F.client.check_key(KEY_RUN) && !F.floorrunning)
+	if(F.client && F.client.check_key(KEY_RUN) && !F.floorrunning && F.resources)
 		F.start_floorrunning()
+
+	if(F.floorrunning)
+		F.resources--
+		if (!F.resources)
+			F.end_floorrunning()
 
 /turf/simulated/wall/auto/feather/Exited(var/mob/living/critter/flock/drone/F, atom/newloc)
 	..()


### PR DESCRIPTION
[FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just adds a resource cost to floorrunning, with placeholder numbers used. When floorrunning, it costs resources per life tick, and when entering a Flocktile.

As implemented, it should be relatively straightforward to change this cost to something else, such as taking energy from an energy bar, if wanted in the future, and modify how often you lose resources, at least for when floorrunning to a new tile.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Floorrunning is powerful and needs something to prevent floorrunning indefinitely.