### PR TITLE
Add toggleable deconstruction

### DIFF
--- a/code/datums/abilities/flock/flockmind.dm
+++ b/code/datums/abilities/flock/flockmind.dm
@@ -457,13 +457,11 @@
 		//this actually doesn't need bonus behaviour because the cancelbuild is on click, but will need to fix this if we change that in future
 		return TRUE
 	else if(HAS_ATOM_PROPERTY(target,PROP_ATOM_FLOCK_THING)) //it's a thing we've converted, we can deconstruct it
-		F.flock.deconstruct_targets += target
-		F.flock.updateAnnotations()
+		F.flock.toggleDeconstructionFlag(target)
 		return FALSE
 	else if(istype(target,/obj/structure/girder)) //special handling for partially decon'd walls - gnesis mats means its ours
 		if(target?.material.mat_id == "gnesis")
-			F.flock.deconstruct_targets += target
-			F.flock.updateAnnotations()
+			F.flock.toggleDeconstructionFlag(target)
 			return FALSE
 
 	return TRUE

--- a/code/datums/flock/flock.dm
+++ b/code/datums/flock/flock.dm
@@ -453,6 +453,12 @@
 		count++
 	return count
 
+/datum/flock/proc/toggleDeconstructionFlag(var/atom/target)
+	if(target in src.deconstruct_targets)
+		src.deconstruct_targets -= target
+	else
+		src.deconstruct_targets += target
+	src.updateAnnotations()
 // ENEMIES
 
 /datum/flock/proc/updateEnemy(atom/M)

--- a/code/mob/living/critter/ai/flock/flocktasks.dm
+++ b/code/mob/living/critter/ai/flock/flocktasks.dm
@@ -954,7 +954,7 @@ butcher
 /datum/aiTask/succeedable/deconstruct/failed()
 	var/mob/living/critter/flock/drone/F = holder.owner
 	var/atom/T = holder.target
-	if(!F || !T || BOUNDS_DIST(T, F) > 0)
+	if(!F || !T || BOUNDS_DIST(T, F) > 0 || !(T in F?.flock?.deconstruct_targets))
 		return TRUE
 
 /datum/aiTask/succeedable/deconstruct/succeeded()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Clicking a thing marked for deconstruction will now stop it being deconstructed and interrupt drones who are on their way to do that.

