### PR TITLE
Moves the target reset from sequence to aiTask

### DIFF
--- a/code/mob/living/critter/ai.dm
+++ b/code/mob/living/critter/ai.dm
@@ -204,7 +204,6 @@ var/list/ai_move_scheduled = list()
 	proc/next_task()
 		return null
 
-	SHOULD_CALL_PARENT(TRUE)
 	proc/on_reset()
 		holder.target = null
 

--- a/code/mob/living/critter/ai.dm
+++ b/code/mob/living/critter/ai.dm
@@ -204,7 +204,9 @@ var/list/ai_move_scheduled = list()
 	proc/next_task()
 		return null
 
+	SHOULD_CALL_PARENT(TRUE)
 	proc/on_reset()
+		holder.target = null
 
 	proc/evaluate() // evaluate the current environment and assign priority to switching to this task
 		return 0

--- a/code/mob/living/critter/ai/shared.dm
+++ b/code/mob/living/critter/ai/shared.dm
@@ -71,9 +71,6 @@
 						return
 			M.move_target = target_turf
 
-/datum/aiTask/sequence/goalbased/on_reset()
-	holder.target = null
-
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 // WANDER TASK
 // spend a few ticks wandering aimlessly


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves the `holder.target = null` so it applies to all aiTasks by default


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes flockdrones trying to deconstruct walls with incapacitors and is probably just a good idea in general
