### PR TITLE
Make ghost structures drop a resource cube on destruction instead of scrap

### DIFF
--- a/code/obj/flock/structure/flock_structure_ghost.dm
+++ b/code/obj/flock/structure/flock_structure_ghost.dm
@@ -77,6 +77,14 @@
 		//not enough resources = do nothin
 	updatealpha()
 
+/obj/flock_structure/ghost/gib()
+	visible_message("<span class='alert'>[src] suddenly dissolves!</span>")
+	playsound(src.loc, 'sound/impact_sounds/Glass_Shatter_2.ogg', 80, 1)
+	if (currentmats > 0)
+		var/obj/item/flockcache/cache = new(get_turf(src))
+		cache.resources = src.currentmats
+	qdel(src)
+
 /obj/flock_structure/ghost/proc/updatealpha()
 	alpha = lerp(104, 255, currentmats / goal)
 


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just makes it so that ghost structures when destroyed drop their resources in a cube rather than scrap.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It fixes a possible farming issue if a ghost structure is destroyed with zero or few resources deposited. Simpler to work with resource cubes rather than possibly varying resources, in the future, from scrap.