### PR TITLE
Prevent drones from reporting dormancy on deletion

### DIFF
--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -208,7 +208,8 @@
 		boutput(controller, "<span class='flocksay'><b>\[SYSTEM: Connection to drone [src.real_name] lost.\]</b></span>")
 		controller = null
 	src.is_npc = TRUE // to ensure right flock_speak message
-	flock_speak(src, "Error: Out of signal range. Disconnecting.", src.flock)
+	if (src.z != Z_LEVEL_NULL)
+		flock_speak(src, "Error: Out of signal range. Disconnecting.", src.flock)
 	src.is_npc = FALSE // turns off ai
 	src.flock = null
 


### PR DESCRIPTION
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes a bug where Flockdrones could report the dormant message for going out of range if sent to nullspace (I think, didn't test).


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix.