### PR TITLE
Standardize material across Flock stuff

### DIFF
--- a/code/mob/living/critter/flockcritter_parent.dm
+++ b/code/mob/living/critter/flockcritter_parent.dm
@@ -14,6 +14,9 @@
 	speechverb_stammer = "buzzes"
 	custom_gib_handler = /proc/flockdronegibs
 	custom_vomit_type = /obj/decal/cleanable/flockdrone_debris/fluid
+	mat_appearances_to_ignore = list("gnesis")
+	mat_changename = FALSE
+	mat_changedesc = FALSE
 	// HEALTHS
 	var/health_brute = 1
 	var/health_burn = 1
@@ -52,6 +55,8 @@
 	..()
 
 	qdel(abilityHolder)
+	setMaterial(getMaterial("gnesis"))
+	src.material.setProperty("reflective", 45)
 	APPLY_ATOM_PROPERTY(src, PROP_MOB_RADPROT, src, 100)
 
 	// do not automatically set up a flock if one is not provided

--- a/code/obj/flock/furniture.dm
+++ b/code/obj/flock/furniture.dm
@@ -18,6 +18,13 @@
 	icon = 'icons/obj/furniture/table_flock.dmi'
 	auto_type = /obj/table/flock/auto
 	parts_type = /obj/item/furniture_parts/table/flock
+	mat_appearances_to_ignore = list("gnesis")
+	mat_changename = FALSE
+	mat_changedesc = FALSE
+
+/obj/table/flock/New()
+	..()
+	setMaterial(getMaterial("gnesis"))
 
 /obj/table/flock/special_desc(dist, mob/user)
   if(isflock(user))
@@ -35,6 +42,13 @@
 	desc = "An extendable... <i>thing</i> that can be stretched out to make, uh, probably a table of some kind? Where's the goddamn instructions?!"
 	icon = 'icons/obj/furniture/table_flock.dmi'
 	furniture_type = /obj/table/flock/auto
+	mat_appearances_to_ignore = list("gnesis")
+	mat_changename = FALSE
+	mat_changedesc = FALSE
+
+/obj/item/furniture_parts/table/flock/New()
+	..()
+	setMaterial(getMaterial("gnesis"))
 
 /obj/item/furniture_parts/table/flock/special_desc(dist, mob/user)
   if(isflock(user))
@@ -59,6 +73,13 @@
 	climbable = 0
 	parts_type = /obj/item/furniture_parts/flock_chair
 	scoot_sounds = list( 'sound/misc/chair/glass/scoot1.ogg', 'sound/misc/chair/glass/scoot2.ogg', 'sound/misc/chair/glass/scoot3.ogg', 'sound/misc/chair/glass/scoot4.ogg', 'sound/misc/chair/glass/scoot5.ogg' )
+	mat_appearances_to_ignore = list("gnesis")
+	mat_changename = FALSE
+	mat_changedesc = FALSE
+
+/obj/stool/chair/comfy/flock/New()
+	..()
+	setMaterial(getMaterial("gnesis"))
 
 /obj/stool/chair/comfy/flock/special_desc(dist, mob/user)
   if(isflock(user))
@@ -78,6 +99,13 @@
 	stamina_cost = 10
 	furniture_type = /obj/stool/chair/comfy/flock
 	furniture_name = "thrumming alcove"
+	mat_appearances_to_ignore = list("gnesis")
+	mat_changename = FALSE
+	mat_changedesc = FALSE
+
+/obj/item/furniture_parts/flock_chair/New()
+	..()
+	setMaterial(getMaterial("gnesis"))
 
 /obj/item/furniture_parts/flock_chair/special_desc(dist, mob/user)
   if(isflock(user))
@@ -193,9 +221,13 @@
 	power_usage = 0
 	on = 1
 	removable_bulb = 0
+	mat_appearances_to_ignore = list("gnesis")
+	mat_changename = 0
+	mat_changedesc = 0
 
 /obj/machinery/light/flock/New()
 	..()
+	setMaterial(getMaterial("gnesis"))
 	light.set_color(0.45, 0.75, 0.675)
 	src.AddComponent(/datum/component/flock_protection, TRUE, FALSE, TRUE)
 

--- a/code/obj/flock/structure/flock_structure_parent.dm
+++ b/code/obj/flock/structure/flock_structure_parent.dm
@@ -7,6 +7,8 @@
 	name = "uh oh"
 	desc = "CALL A CODER THIS SHOULDN'T BE SEEN"
 	flags = USEDELAY
+	mat_changename = FALSE
+	mat_changedesc = FALSE
 	var/flock_id = "ERROR"
 	/// when did we get created?
 	var/time_started = 0

--- a/code/obj/machinery/door/feather.dm
+++ b/code/obj/machinery/door/feather.dm
@@ -5,6 +5,8 @@
 	name = "weird imposing wall"
 	desc = "It sounds like it's hollow."
 	mat_appearances_to_ignore = list("steel","gnesis")
+	mat_changename = FALSE
+	mat_changedesc = FALSE
 	autoclose = 1
 	var/broken = 0
 	health = 80

--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -1059,7 +1059,6 @@
 
 /obj/window/feather/New()
 	..()
-	setMaterial(getMaterial("gnesis"))
 	src.AddComponent(/datum/component/flock_protection, FALSE, TRUE, TRUE)
 
 /obj/window/feather/special_desc(dist, mob/user)

--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -1050,12 +1050,16 @@
 	default_material = "gnesisglass"
 	hitsound = 'sound/impact_sounds/Crystal_Hit_1.ogg'
 	shattersound = 'sound/impact_sounds/Crystal_Shatter_1.ogg'
+	mat_appearances_to_ignore = list("gnesis")
+	mat_changename = FALSE
+	mat_changedesc = FALSE
 	health = 50 // as strong as reinforced glass, but not as strong as plasmaglass
 	health_max = 50
 	density = 1
 
 /obj/window/feather/New()
 	..()
+	setMaterial(getMaterial("gnesis"))
 	src.AddComponent(/datum/component/flock_protection, FALSE, TRUE, TRUE)
 
 /obj/window/feather/special_desc(dist, mob/user)

--- a/code/turf/turf_flock.dm
+++ b/code/turf/turf_flock.dm
@@ -275,6 +275,8 @@ turf/simulated/floor/feather/proc/bfs(turf/start)//breadth first search, made by
 	var/max_health = 250
 	flags = USEDELAY
 	mat_appearances_to_ignore = list("steel", "gnesis")
+	mat_changename = FALSE
+	mat_changedesc = FALSE
 	connects_to = list(/turf/simulated/wall/auto/feather, /obj/machinery/door/feather)
 
 	var/broken = FALSE


### PR DESCRIPTION
[FEATURE][BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR standardizes how material properties are set across all Flock stuff. It gives Flock stuff that didn't have the gnesis material the gnesis material, prevents some Flock stuff that had the gnesis material from showing that in its name and description, and fixes chairs and alcoves giving steel sheets when deconstructed.

Only thing I noticed was that Flock windows are now opaque. Wasn't sure if opacity should be set manually or the material itself changed.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Consistency and bug fixes.