### PR TITLE
Add Flockmind promotion framework

### DIFF
--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -111,7 +111,7 @@
 		controller = new/mob/living/intangible/flock/trace(src, src.flock)
 		src.is_npc = 0
 
-/mob/living/critter/flock/drone/proc/take_control(mob/living/intangible/flock/pilot)
+/mob/living/critter/flock/drone/proc/take_control(mob/living/intangible/flock/pilot, give_alert = TRUE)
 	if(!pilot)
 		return // fuck it
 	if(controller)
@@ -141,13 +141,15 @@
 	controller = pilot
 	src.client?.color = null // stop being all fucked up and weird aaaagh
 	src.hud?.update_intent()
-	boutput(src, "<span class='flocksay'><b>\[SYSTEM: Control of drone [src.real_name] established.\]</b></span>")
+	if (give_alert)
+		boutput(src, "<span class='flocksay'><b>\[SYSTEM: Control of drone [src.real_name] established.\]</b></span>")
 
-/mob/living/critter/flock/drone/proc/release_control()
+/mob/living/critter/flock/drone/proc/release_control(give_alerts = TRUE)
 	src.flock?.hideAnnotations(src)
 	src.is_npc = 1
-	emote("beep")
-	say(pick_string("flockmind.txt", "flockdrone_player_kicked"))
+	if (give_alerts)
+		emote("beep")
+		say(pick_string("flockmind.txt", "flockdrone_player_kicked"))
 	if(src.client && !controller)
 		// don't know how this happened but you need a controller right now
 		controller = new/mob/living/intangible/flock/trace(src, src.flock)
@@ -173,7 +175,8 @@
 				controller.mind.key = key
 				controller.mind.current = controller
 				ticker.minds += controller.mind
-		flock_speak(null, "Control of drone [src.real_name] surrended.", src.flock)
+		if (give_alerts)
+			flock_speak(null, "Control of drone [src.real_name] surrended.", src.flock)
 		// clear refs
 		controller = null
 

--- a/code/mob/living/intangible/flock/flocktrace.dm
+++ b/code/mob/living/intangible/flock/flocktrace.dm
@@ -68,6 +68,33 @@
 		stat("Flock:", "none")
 		stat("Drones:", 0)
 
+/mob/living/intangible/flock/trace/proc/promoteToFlockmind(remove_flockmind_from_flock)
+	var/was_in_drone = FALSE
+	var/mob/living/critter/flock/drone/controlled = src.loc
+	if (istype(controlled))
+		was_in_drone = TRUE
+		controlled.release_control(FALSE)
+
+	boutput(src, "<span class='flocksay'><b>\[SYSTEM: New functions detected. Control of Flock assumed.\]</b></span>")
+	flock_speak(null, "Flocktrace [src.real_name] has been promoted to Flockmind.", src.flock)
+
+	var/mob/living/intangible/flock/flockmind/original = src.flock.flockmind
+	if (!remove_flockmind_from_flock)
+		src.mind.swap_with(original)
+		if (was_in_drone)
+			src.set_loc(get_turf(original))
+			controlled.take_control(original, FALSE)
+	else
+		var/mob/living/intangible/flock/flockmind/F = new (get_turf(src), src.flock)
+		src.mind.transfer_to(F)
+		if (was_in_drone)
+			controlled.take_control(F, FALSE)
+		src.flock.removeTrace(src)
+		src.flock.hideAnnotations(original)
+		original.ghostize()
+		qdel(original)
+		qdel(src)
+
 /mob/living/intangible/flock/trace/Life(datum/controller/process/mobs/parent)
 	if (..(parent))
 		return 1

--- a/code/mob/living/intangible/flock/flocktrace.dm
+++ b/code/mob/living/intangible/flock/flocktrace.dm
@@ -79,12 +79,7 @@
 	flock_speak(null, "Flocktrace [src.real_name] has been promoted to Flockmind.", src.flock)
 
 	var/mob/living/intangible/flock/flockmind/original = src.flock.flockmind
-	if (!remove_flockmind_from_flock)
-		src.mind.swap_with(original)
-		if (was_in_drone)
-			src.set_loc(get_turf(original))
-			controlled.take_control(original, FALSE)
-	else
+	if (remove_flockmind_from_flock)
 		var/mob/living/intangible/flock/flockmind/F = new (get_turf(src), src.flock)
 		src.mind.transfer_to(F)
 		if (was_in_drone)
@@ -94,6 +89,11 @@
 		original.ghostize()
 		qdel(original)
 		qdel(src)
+	else
+		src.mind.swap_with(original)
+		if (was_in_drone)
+			src.set_loc(get_turf(original))
+			controlled.take_control(original, FALSE)
 
 /mob/living/intangible/flock/trace/Life(datum/controller/process/mobs/parent)
 	if (..(parent))


### PR DESCRIPTION
[FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds procs in that may be used elsewhere for allowing the Flockmind to promote Flocktraces to Flockmind.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It would be nice for the Flockmind to be able to give another entity control of the flock if they need to leave or go afk.