### PR TITLE
Make flocktraces be antags

### DIFF
--- a/_std/defines/roles.dm
+++ b/_std/defines/roles.dm
@@ -33,6 +33,7 @@
 // gimmicks
 #define ROLE_BATTLER "battler"
 #define ROLE_FLOCKMIND "flockmind"
+#define ROLE_FLOCKTRACE "flocktrace"
 #define ROLE_OMNITRAITOR "omnitraitor"
 #define ROLE_GRINCH "grinch"
 #define ROLE_FLOOR_GOBLIN "floor_goblin"

--- a/code/mob/living/intangible/flock/flocktrace.dm
+++ b/code/mob/living/intangible/flock/flocktrace.dm
@@ -27,6 +27,12 @@
 		src.flock.addTrace(src)
 	else
 		src.death() // f u
+
+	if (!src.mind.special_role) // Preserve existing antag role (if any).
+		src.mind.special_role = ROLE_FLOCKTRACE
+	if (!(src.mind in ticker.mode.Agimmicks))
+		ticker.mode.Agimmicks += src.mind
+
 	src.addAbility(/datum/targetable/flockmindAbility/designateEnemy)
 	src.addAbility(/datum/targetable/flockmindAbility/ping)
 

--- a/code/mob/living/intangible/flock/flocktrace.dm
+++ b/code/mob/living/intangible/flock/flocktrace.dm
@@ -28,11 +28,6 @@
 	else
 		src.death() // f u
 
-	if (!src.mind.special_role) // Preserve existing antag role (if any).
-		src.mind.special_role = ROLE_FLOCKTRACE
-	if (!(src.mind in ticker.mode.Agimmicks))
-		ticker.mode.Agimmicks += src.mind
-
 	src.addAbility(/datum/targetable/flockmindAbility/designateEnemy)
 	src.addAbility(/datum/targetable/flockmindAbility/ping)
 

--- a/code/mob/transform_procs.dm
+++ b/code/mob/transform_procs.dm
@@ -884,6 +884,11 @@ var/respawn_arena_enabled = 0
 			O.mind.key = key
 			O.mind.current = O
 			ticker.minds += O.mind
+
+		if (!src.mind?.special_role) // Preserve existing antag role (if any).
+			src.mind.special_role = ROLE_FLOCKTRACE
+		if (!(src.mind in ticker.mode.Agimmicks))
+			ticker.mode.Agimmicks += src.mind
 		qdel(src)
 
 		boutput(O, "<span class='bold'>You are a Flocktrace, a partition of the Flock's collective computation!</span>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Anyone who gets flocktrace'd will now be added to the antag list and recieve the little V symbol for admins


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #235
