### PR TITLE
Allow drones to attack pods

### DIFF
--- a/_std/macros/vehicles.dm
+++ b/_std/macros/vehicles.dm
@@ -1,3 +1,4 @@
 //used for pods
 
 #define BOARD_DIST_ALLOWED(M,V) ( can_reach(M, V) )
+#define isvehicle(x) istype(x, /obj/machinery/vehicle) || istype(x, /obj/vehicle)

--- a/code/datums/abilities/flock/flockmind.dm
+++ b/code/datums/abilities/flock/flockmind.dm
@@ -160,7 +160,7 @@
 	var/M = target
 	var/mob/living/intangible/flock/F = holder.owner
 
-	if (!(isliving(M) || iscritter(M)) || isflock(M) || isintangible(M))
+	if (!(isliving(M) || iscritter(M) || isvehicle(M)) || isflock(M) || isintangible(M))
 		boutput(F, "<span class='alert'>That isn't a valid target.</span>")
 		return TRUE
 

--- a/code/datums/flock/flock.dm
+++ b/code/datums/flock/flock.dm
@@ -464,6 +464,9 @@
 /datum/flock/proc/updateEnemy(atom/M)
 	if(!M)
 		return
+	if (isvehicle(M))
+		for (var/mob/occupant in M) //yes we are blaming the passenger
+			src.updateEnemy(occupant)
 	if(!isliving(M) && !iscritter(M))
 		return
 	var/enemy_name = M

--- a/code/datums/flock/flock.dm
+++ b/code/datums/flock/flock.dm
@@ -413,7 +413,8 @@
 	if (isvehicle(M))
 		for (var/mob/occupant in M) //yes we are blaming the passenger
 			src.updateEnemy(occupant)
-	if(!isliving(M) && !iscritter(M))
+	//vehicles can be enemies but drones will only attack them if they are occupied
+	if(!isliving(M) && !iscritter(M) && !isvehicle(M))
 		return
 	var/enemy_name = M
 	var/list/enemy_deets
@@ -438,7 +439,7 @@
 
 /datum/flock/proc/removeEnemy(atom/M)
 	// call off all drones attacking this guy
-	if(!isliving(M) && !iscritter(M))
+	if(!isliving(M) && !iscritter(M) && !isvehicle(M))
 		return
 	src.enemies -= M
 

--- a/code/mob/living/critter/ai/flock/flocktasks.dm
+++ b/code/mob/living/critter/ai/flock/flocktasks.dm
@@ -760,16 +760,18 @@ butcher
 	for(var/atom/T in view(target_range, holder.owner))
 		//handle vehicles first
 		if (isvehicle(T))
+			var/vehicle_is_enemy = F.flock.isEnemy(T) //if someone gets in an enemy pod, attack
 			var/enemy_found = FALSE
 			for (var/mob/occupant in T)
-				if (!F.flock.isEnemy(occupant))
+				if (!F.flock.isEnemy(occupant) && !vehicle_is_enemy)
 					continue
 				F.flock.updateEnemy(occupant)
 				enemy_found = TRUE
 				break
 			if (enemy_found) //bad guy in pod
 				. += T
-				continue
+			//continue regardless of whether we find an enemy or not, since we don't want to attack empty pods
+			continue
 		if(!F.flock.isEnemy(T))
 			continue
 		if(isliving(T))
@@ -811,6 +813,8 @@ butcher
 /datum/aiTask/sequence/goalbased/flockdrone_capture/valid_target(atom/target)
 	var/mob/living/critter/flock/drone/F = holder.owner
 	if(!F.flock.isEnemy(target))
+		return FALSE
+	if (!ismob(target) && !iscritter(target)) //no caging vehicles
 		return FALSE
 	if(istype(target,/mob/living))
 		var/mob/living/mob = target

--- a/code/mob/living/critter/ai/flock/flocktasks.dm
+++ b/code/mob/living/critter/ai/flock/flocktasks.dm
@@ -758,13 +758,24 @@ butcher
 	if(!F?.flock)
 		return
 	for(var/atom/T in view(target_range, holder.owner))
+		//handle vehicles first
+		if (isvehicle(T))
+			var/enemy_found = FALSE
+			for (var/mob/occupant in T)
+				if (!F.flock.isEnemy(occupant))
+					continue
+				F.flock.updateEnemy(occupant)
+				enemy_found = TRUE
+				break
+			if (enemy_found) //bad guy in pod
+				. += T
+				continue
 		if(!F.flock.isEnemy(T))
 			continue
 		if(isliving(T))
 			var/mob/living/M = T
 			if(is_incapacitated(M))
 				continue
-
 		// mob is a valid target, check if they're not already in a cage
 		if(!istype(T.loc.type, /obj/flock_structure/cage))
 			// if we can get a valid path to the target, include it for consideration
@@ -1184,7 +1195,7 @@ butcher
 /datum/aiTask/timed/targeted/flockdrone_shoot/targetable
 	switched_to()
 		on_reset()
-		if (!(ismob(src.target) || iscritter(src.target)) || isflock(src.target))
+		if (!(ismob(src.target) || iscritter(src.target) || isvehicle(src.target)) || isflock(src.target))
 			var/mob/living/critter/flock/drone/drone = holder.owner
 			flock_speak(drone, "Invalid elimination target provided by sentient level instruction.", drone.flock)
 			holder.interrupt()

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -596,8 +596,8 @@
 		src.visible_message("<span class='notice'>[src] harmlessly absorbs [P].</span>")
 	else
 		..()
-		var/mob/attacker = P.shooter
-		if(istype(attacker))
+		var/attacker = P.shooter
+		if(attacker)
 			src.harmedBy(attacker)
 
 /mob/living/critter/flock/drone/hitby(atom/movable/AM, datum/thrown_thing/thr)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Hitting a drone with a pod laser now marks all occupants and the pod itself as enemies, drones will shoot at any pod that contains an enemy and if a drone sees you in an enemy pod you will be marked as an enemy.
Fixes #233
Also adds `isvehicle` because for some reason that didn't exist (probably missing a few types as well)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Pods are already a decent counter to flock, letting drones slowly mob them to death is important