### PR TITLE
Make Flockdrone abilities unresumable

### DIFF
--- a/code/mob/living/critter/flockcritter_parent.dm
+++ b/code/mob/living/critter/flockcritter_parent.dm
@@ -167,6 +167,7 @@
 	id = "flock_convert"
 	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION
 	duration = 45
+	resumable = FALSE
 
 	var/turf/simulated/target
 	var/obj/decal/decal
@@ -236,6 +237,7 @@
 	id = "flock_construct"
 	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION
 	duration = 30
+	resumable = FALSE
 
 	var/turf/simulated/target
 	var/obj/decal/decal
@@ -299,6 +301,7 @@
 	id = "flock_egg"
 	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION
 	duration = 80
+	resumable = FALSE
 
 	New(var/duration_i)
 		..()
@@ -340,6 +343,7 @@
 	id = "flock_repair"
 	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION
 	duration = 10
+	resumable = FALSE
 
 	var/atom/target
 
@@ -421,6 +425,7 @@
 	id = "flock_entomb"
 	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION
 	duration = 60
+	resumable = FALSE
 
 	var/atom/target
 	var/obj/decal/decal
@@ -481,6 +486,7 @@
 	id = "flock_decon"
 	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION
 	duration = 60
+	resumable = FALSE
 
 	var/atom/target
 
@@ -575,6 +581,7 @@
 	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION
 	var/const/default_duration = 1 SECOND
 	duration = default_duration
+	resumable = FALSE
 	color_success = "#4444FF"
 	var/obj/flock_structure/ghost/target = null
 


### PR DESCRIPTION
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just makes the Flockdrone abilities unresumable, based on what Pali suggested in the linked issue.

I guess this now makes some sound spam possible, which could be accounted for with cooldowns, but not sure if that was the best solution considering the sound isn't much of a problem for when you aren't intentionally doing that.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix, fixes #247.

Also fixes some related ability exploits possible by starting one of these abilities on a tile and ending it while on another tile and spam clicking over the distance, allowing you to do stuff such as converting a tile to flock from several tiles away.