### PR TITLE
Prevent flockdrones from admin messaging on attack after spawning

### DIFF
--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -806,6 +806,9 @@
 			continue // no UI elements please
 		. += O
 
+/mob/living/critter/flock/drone/message_admin_on_attack()
+	return
+
 // TODO: do this better
 /mob/living/critter/flock/drone/change_eye_blurry(var/amount, var/cap = 0)
 	if (amount < 0)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #238


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
it's normal for flockdrones to be attacked right after spawning.