### PR TITLE
Cuts relay charge time to 6 minutes and adds a crew announcement for it

### DIFF
--- a/code/obj/flock/structure/relay.dm
+++ b/code/obj/flock/structure/relay.dm
@@ -22,7 +22,7 @@
 	plane = PLANE_NOSHADOW_ABOVE
 	var/last_time_sound_played_in_seconds = 0
 	var/sound_length_in_seconds = 27
-	var/charge_time_length = 600 // also in seconds
+	var/charge_time_length = 360 // also in seconds
 	var/final_charge_time_length = 18
 	var/col_r = 0.1
 	var/col_g = 0.7
@@ -42,6 +42,10 @@
 	flock_speak(null, "RELAY CONSTRUCTED! DEFEND THE RELAY!!", src.flock)
 	SPAWN(1 SECOND)
 		radial_flock_conversion(src, 20)
+	SPAWN(10 SECONDS)
+		var/msg = "Overwhelming anomalous power signatures detected on station. This is an existential threat to the station. All personnel must contain this event."
+		msg = radioGarbleText(msg, 7)
+		command_alert(msg, sound_to_play = "sound/misc/announcement_1.ogg", alert_origin = ALERT_ANOMALY)
 
 /obj/flock_structure/relay/disposing()
 	..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Relay charge time from 600 -> 360 seconds.
![image](https://user-images.githubusercontent.com/20713227/167077600-d55460ed-2a51-44e7-bc8b-99bdc7317bfb.png)
"Overwhelming anomalous power signatures detected on station. This is an existential threat to the station. All personnel must contain this event."

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
10 minutes seemed like a very long time during playtesting, and right now there's no real indicator that the crew are supposed to immediately drop everything and destroy the relay so I've added a vague and slightly garbled announcement.