### PR TITLE
Prevents beepsky from opening featherdoors

### DIFF
--- a/_std/pathfinding.dm
+++ b/_std/pathfinding.dm
@@ -447,7 +447,7 @@
 							continue
 						else
 							return FALSE
-					else //we must be a public door
+					else if (O.allowed(passer)) //even if it has no access, it might not let us pass
 						continue
 				return FALSE
 		else if(!A.Cross(passer))

--- a/code/obj/machinery/door/door_parent.dm
+++ b/code/obj/machinery/door/door_parent.dm
@@ -33,7 +33,7 @@
 	var/sound_deny = 0
 	var/has_crush = 1 //flagged to true when the door has a secret admirer. also if the var == 1 then the door doesn't have the ability to crush items.
 	var/close_trys = 0
-	var/alien = FALSE
+	var/alien = FALSE /// is a weird alien door that secbots shouldn't be able to open
 
 	var/health = 400
 	var/health_max = 400

--- a/code/obj/machinery/door/door_parent.dm
+++ b/code/obj/machinery/door/door_parent.dm
@@ -33,6 +33,7 @@
 	var/sound_deny = 0
 	var/has_crush = 1 //flagged to true when the door has a secret admirer. also if the var == 1 then the door doesn't have the ability to crush items.
 	var/close_trys = 0
+	var/alien = FALSE
 
 	var/health = 400
 	var/health_max = 400
@@ -71,7 +72,7 @@
 
 	else if (istype(AM, /obj/machinery/bot))
 		var/obj/machinery/bot/B = AM
-		if (src.check_access(B.botcard))
+		if (!src.alien && src.check_access(B.botcard))
 			if (src.density)
 				src.open()
 

--- a/code/obj/machinery/door/feather.dm
+++ b/code/obj/machinery/door/feather.dm
@@ -139,6 +139,7 @@
 ////////////////////
 /obj/machinery/door/feather/friendly
 	// whee
+	alien = FALSE //non flock are allowed
 
 /obj/machinery/door/feather/friendly/allowed(mob/M)
 	return 1 // everyone welcome

--- a/code/obj/machinery/door/feather.dm
+++ b/code/obj/machinery/door/feather.dm
@@ -11,6 +11,7 @@
 	var/broken = 0
 	health = 80
 	health_max = 80
+	alien = TRUE
 
 /obj/machinery/door/feather/New()
 	..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #87, also modifies the pathfinding code slightly to account for doors with no access requirements that have `allowed` checks so beepsky doesn't bang his head.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
While beepsky *is* the law, flock probably shouldn't respect the law.