### PR TITLE
Move shared Flock critter stuff to parent procs

### DIFF
--- a/code/mob/living/critter/flock/flockbit.dm
+++ b/code/mob/living/critter/flock/flockbit.dm
@@ -54,12 +54,6 @@
 	else
 		..()
 
-/mob/living/critter/flock/bit/bullet_act(var/obj/projectile/P)
-	if(istype(P.proj_data, /datum/projectile/energy_bolt/flockdrone))
-		src.visible_message("<span class='notice'>[src] harmlessly absorbs [P].</span>")
-		return
-	..()
-
 /mob/living/critter/flock/bit/setup_hands()
 	..()
 	var/datum/handHolder/HH = hands[1]
@@ -82,29 +76,19 @@
 	HH.can_attack = 1
 	HH.can_range_attack = 0
 
-/mob/living/critter/flock/bit/proc/dormantize()
-	src.dormant = TRUE
+/mob/living/critter/flock/bit/dormantize()
 	src.icon_state = "bit-dormant"
-	src.ai.die()
 	animate(src) // doesnt work right now
-
-	if (!src.flock)
-		return
-
-	src.flock.removeDrone(src)
-	src.flock = null
+	..()
 
 /mob/living/critter/flock/bit/death(var/gibbed)
-	walk(src, 0)
-	src.flock?.removeDrone(src)
-	playsound(src, "sound/impact_sounds/Glass_Shatter_3.ogg", 50, 1)
+	..()
 	flockdronegibs(get_turf(src))
-	if (src.mind || src.client) //Shouldn't be possible, but someone managed it
+	if (src.mind || src.client)
 		src.ghostize()
 	qdel(src)
 
 /mob/living/critter/flock/bit/disposing()
-	src.flock?.removeDrone(src)
 	if (src.mind || src.client)
 		src.ghostize()
 	..()

--- a/code/mob/living/critter/flockcritter_parent.dm
+++ b/code/mob/living/critter/flockcritter_parent.dm
@@ -81,6 +81,22 @@
 		state["area"] = "???"
 	return state
 
+/mob/living/critter/flock/proc/dormantize()
+	src.dormant = TRUE
+	src.ai?.die()
+
+	if (!src.flock)
+		return
+
+	src.flock.removeDrone(src)
+	src.flock = null
+
+/mob/living/critter/flock/bullet_act(var/obj/projectile/P)
+	if(istype(P.proj_data, /datum/projectile/energy_bolt/flockdrone))
+		src.visible_message("<span class='notice'>[src] harmlessly absorbs [P].</span>")
+		return FALSE
+	..()
+
 //compute - override if behaviour is weird
 /mob/living/critter/flock/proc/compute_provided()
 	return src.compute
@@ -153,6 +169,18 @@
 	else
 		// tell whoever's controlling the critter to come to the flockmind, pronto
 		boutput(src, "<span class='flocksay'><b>\[SYSTEM: The flockmind requests your presence immediately.\]</b></span>")
+
+/mob/living/critter/flock/death(var/gibbed)
+	..()
+	src.ai.die()
+	walk(src, 0)
+	src.flock?.removeDrone(src)
+	playsound(src, "sound/impact_sounds/Glass_Shatter_3.ogg", 50, 1)
+
+/mob/living/critter/flock/disposing()
+	if (src.flock)
+		src.flock.removeDrone(src)
+	..()
 
 //////////////////////////////////////////////////////
 // VARIOUS FLOCK ACTIONS


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just moves some stuff shared between Flockdrones and Flockcritters to parent procs.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Cleanliness.