### PR TITLE
Restrict some Flock stuff from being marked for deconstruction or deconstructed

### DIFF
--- a/_std/macros/flock.dm
+++ b/_std/macros/flock.dm
@@ -2,3 +2,4 @@
 #define isfeathertile(x) (istype(x, /turf/simulated/floor/feather) || istype(x, /turf/simulated/wall/auto/feather))
 #define isflock(x) (istype(x, /mob/living/intangible/flock) || istype(x, /mob/living/critter/flock))
 #define isflockstructure(x) (istype(x, /obj/flock_structure))
+#define isflockdeconimmune(x) (istype(target, /obj/flock_structure/ghost) || istype(target, /mob/living/critter/flock) || istype(target, /turf/simulated/floor/feather) || istype(target, /obj/flock_structure/rift) || istype(target, /obj/flock_structure/egg) || istype(target, /obj/flock_structure/relay))

--- a/code/datums/abilities/flock/flockmind.dm
+++ b/code/datums/abilities/flock/flockmind.dm
@@ -459,12 +459,11 @@
 	if(..())
 		return TRUE
 	var/mob/living/intangible/flock/F = holder.owner
-	//special handling for building ghosts
-	if(istype(target,/obj/flock_structure/ghost))
-		//do the tgui window instead
-		//this actually doesn't need bonus behaviour because the cancelbuild is on click, but will need to fix this if we change that in future
-		return TRUE
-	else if(HAS_ATOM_PROPERTY(target,PROP_ATOM_FLOCK_THING)) //it's a thing we've converted, we can deconstruct it
+	if(HAS_ATOM_PROPERTY(target,PROP_ATOM_FLOCK_THING))
+		if(istype(target,/obj/flock_structure/ghost))
+			return TRUE // does tgui window for canceling since cancelbuild is on click, will need to fix this if we change it in the future
+		if (istype(target, /mob/living/critter/flock) || istype(target, /turf/simulated/floor/feather) || istype(target, /obj/flock_structure/rift) || istype(target, /obj/flock_structure/egg) || istype(target, /obj/flock_structure/relay))
+			return TRUE
 		F.flock.toggleDeconstructionFlag(target)
 		return FALSE
 	else if(istype(target,/obj/structure/girder)) //special handling for partially decon'd walls - gnesis mats means its ours

--- a/code/datums/abilities/flock/flockmind.dm
+++ b/code/datums/abilities/flock/flockmind.dm
@@ -460,9 +460,7 @@
 		return TRUE
 	var/mob/living/intangible/flock/F = holder.owner
 	if(HAS_ATOM_PROPERTY(target,PROP_ATOM_FLOCK_THING))
-		if(istype(target,/obj/flock_structure/ghost))
-			return TRUE // does tgui window for canceling since cancelbuild is on click, will need to fix this if we change it in the future
-		if (istype(target, /mob/living/critter/flock) || istype(target, /turf/simulated/floor/feather) || istype(target, /obj/flock_structure/rift) || istype(target, /obj/flock_structure/egg) || istype(target, /obj/flock_structure/relay))
+		if (isflockdeconimmune(target)) // ghost structure on click opens tgui window
 			return TRUE
 		F.flock.toggleDeconstructionFlag(target)
 		return FALSE

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -922,9 +922,9 @@
 			else
 				actions.start(new/datum/action/bar/flock_convert(target), user)
 	if(user.a_intent == INTENT_HARM)
-		if(istype(target, /obj/flock_structure/ghost))
-			return
 		if(HAS_ATOM_PROPERTY(target,PROP_ATOM_FLOCK_THING))
+			if(istype(target, /obj/flock_structure/ghost) || istype(target, /turf/simulated/floor/feather) || istype(target, /obj/flock_structure/egg) || istype(target, /obj/flock_structure/relay))
+				return
 			actions.start(new /datum/action/bar/flock_decon(target), user)
 		else if(istype(target,/obj/structure/girder)) //special handling for partially deconstructed walls
 			if(target?.material.mat_id == "gnesis")

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -923,7 +923,7 @@
 				actions.start(new/datum/action/bar/flock_convert(target), user)
 	if(user.a_intent == INTENT_HARM)
 		if(HAS_ATOM_PROPERTY(target,PROP_ATOM_FLOCK_THING))
-			if(istype(target, /obj/flock_structure/ghost) || istype(target, /turf/simulated/floor/feather) || istype(target, /obj/flock_structure/egg) || istype(target, /obj/flock_structure/relay))
+			if(isflockdeconimmune(target))
 				return
 			actions.start(new /datum/action/bar/flock_decon(target), user)
 		else if(istype(target,/obj/structure/girder)) //special handling for partially deconstructed walls


### PR DESCRIPTION
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes being able to mark some Flock stuff for deconstruction and deconstruct some stuff that shouldn't be able to be marked or deconstructed.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix.