### PR TITLE
Fix runtimes while checking for disposed busy stuff

### DIFF
--- a/code/datums/flock/flock.dm
+++ b/code/datums/flock/flock.dm
@@ -575,21 +575,21 @@
 	var/turf/busy_turf
 	for(var/name in src.busy_tiles)
 		busy_turf = src.busy_tiles[name]
-		if (busy_turf.disposed)
+		if (QDELETED(busy_turf))
 			src.unreserveTurf(busy_turf)
 
 	for(var/turf/T in src.priority_tiles)
-		if (T.disposed)
+		if (QDELETED(T))
 			src.togglePriorityTurf(T)
 
 	for(var/atom/S in src.deconstruct_targets)
-		if(S.disposed)
+		if(QDELETED(S))
 			src.toggleDeconstructionFlag(S)
 
 	var/atom/M
 	for(var/enemy in src.enemies)
 		M = src.enemies[enemy]["mob"]
-		if (M.disposed)
+		if (QDELETED(M))
 			src.removeEnemy(M)
 
 /datum/flock/proc/convert_turf(var/turf/T, var/converterName)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[runtime]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes `null.disposed` runtimes by switching to `QDELETED`

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Runtimes bad