### PR TITLE
Better wandering

### DIFF
--- a/code/mob/living/critter/ai/flock/flockdrone.dm
+++ b/code/mob/living/critter/ai/flock/flockdrone.dm
@@ -26,7 +26,7 @@
 	transition_tasks += holder.get_instance(/datum/aiTask/sequence/goalbased/flockdrone_capture, list(holder, src))
 	transition_tasks += holder.get_instance(/datum/aiTask/sequence/goalbased/deconstruct, list(holder, src))
 	transition_tasks += holder.get_instance(/datum/aiTask/sequence/goalbased/stare, list(holder, src))
-	transition_tasks += holder.get_instance(/datum/aiTask/timed/wander, list(holder, src))
+	transition_tasks += holder.get_instance(/datum/aiTask/timed/wander/flock, list(holder, src))
 
 /datum/aiTask/prioritizer/flock/drone/on_reset()
 	..()

--- a/code/mob/living/critter/ai/flock/flocktasks.dm
+++ b/code/mob/living/critter/ai/flock/flocktasks.dm
@@ -1234,9 +1234,9 @@ butcher
 	var/list/turfs = list()
 	path = null
 	targetpos = null
-	for(var/turf/tmpturf in range(holder.owner,2))
-		if(!istype(tmpturf,/turf/space) && !is_blocked_turf(tmpturf) && GET_DIST(holder.owner,startpos) <= GET_DIST(tmpturf,startpos))
-			turfs += tmpturf
+	for(var/turf/T in range(holder.owner,2))
+		if(!istype(T,/turf/space) && !is_blocked_turf(T) && GET_DIST(holder.owner,startpos) <= GET_DIST(T,startpos))
+			turfs += T
 	if(!length(turfs))
 		//oh shit we must be in space, better wander in the direction of the station
 		turfs += pick_landmark(LANDMARK_LATEJOIN)

--- a/code/mob/living/critter/ai/flock/flocktasks.dm
+++ b/code/mob/living/critter/ai/flock/flocktasks.dm
@@ -1210,3 +1210,38 @@ butcher
 	on_reset()
 		..()
 		holder.target = src.target
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+/// Wander override for better wandering
+/datum/aiTask/timed/wander/flock
+	minimum_task_ticks = 5
+	maximum_task_ticks = 7 //you go a lot further with this wandering, so shorten the task time
+	var/turf/startpos
+	var/turf/targetpos
+	var/path
+
+/datum/aiTask/timed/wander/flock/on_tick()
+	if(!startpos)
+		startpos = get_turf(holder.owner)
+	if(targetpos && GET_DIST(holder.owner,targetpos) > 0) //if we have a target and we're not already there
+		if(!path || !length(path))
+			path = get_path_to(holder.owner, targetpos, 5, 1) //short search, we don't want this to be expensive
+		if(length(path))
+			holder.move_to_with_path(targetpos, path, 0)
+			return
+
+	//pick a random tile that is not space, and not closer to startpos than we are now
+	var/list/turfs = list()
+	path = null
+	targetpos = null
+	for(var/turf/tmpturf in range(holder.owner,2))
+		if(!istype(tmpturf,/turf/space) && !is_blocked_turf(tmpturf) && GET_DIST(holder.owner,startpos) <= GET_DIST(tmpturf,startpos))
+			turfs += tmpturf
+	if(!length(turfs))
+		//oh shit we must be in space, better wander in the direction of the station
+		turfs += pick_landmark(LANDMARK_LATEJOIN)
+	if(length(turfs))
+		targetpos = pick(turfs)
+	else
+		//well I guess the station is gone and everyone is dead. Back to default wander behaviour
+		..()

--- a/code/mob/living/critter/ai/shared.dm
+++ b/code/mob/living/critter/ai/shared.dm
@@ -91,9 +91,6 @@
 	// thanks byond forums for letting me know that the byond native implentation FUCKING SUCKS
 	holder.owner.move_dir = pick(alldirs)
 	holder.owner.process_move()
-
-/datum/aiTask/timed/wander/on_tick()
-	. = ..()
 	holder.stop_move()
 	holder.owner.move_dir = null // clear out direction so it doesn't get latched when client is attached
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes wandering smarter for flockdrones. They now avoid space tiles, actively path away from where they started wandering, and use smarter pathing. They also head back towards the station if they somehow end up in space.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Previous behaviour sucked.

