### PR TITLE
Flockdrone/bits no longer metabolise chems

### DIFF
--- a/code/mob/living/critter/flockcritter_parent.dm
+++ b/code/mob/living/critter/flockcritter_parent.dm
@@ -19,6 +19,8 @@
 	// HEALTHS
 	var/health_brute = 1
 	var/health_burn = 1
+	// no medicine for radio birds
+	metabolizes = FALSE
 	//base compute provided
 	var/compute = 0
 	// if we're extinguishing ourselves don't extinguish ourselves repeatedly


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Disables chem metabolism on flock critters. This means meds will do nothing but accumulate. You can squeeze them out of the flock heart after they die if you want.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #285 
