### PR TITLE
Add flock parameter to Flock mass conversion procs

### DIFF
--- a/code/datums/flock/flock.dm
+++ b/code/datums/flock/flock.dm
@@ -737,16 +737,16 @@
 
 	return T
 
-/proc/mass_flock_convert_turf(var/turf/T)
+/proc/mass_flock_convert_turf(var/turf/T, datum/flock/F)
 	// a terrible idea
 	if(!T)
 		T = get_turf(usr)
 	if(!T)
 		return // not sure if this can happen, so it will
 
-	flock_spiral_conversion(T)
+	flock_spiral_conversion(T, F)
 
-/proc/radial_flock_conversion(var/atom/movable/source, var/max_radius=20)
+/proc/radial_flock_conversion(var/atom/movable/source, datum/flock/F, var/max_radius=20)
 	if(!source) return
 	var/turf/T = get_turf(source)
 	var/radius = 1
@@ -755,7 +755,10 @@
 		LAGCHECK(LAG_LOW)
 		for(var/turf/tile in turfs)
 			if(istype(tile, /turf/simulated) && !isfeathertile(tile))
-				flock_convert_turf(tile)
+				if (F)
+					F.claimTurf(flock_convert_turf(tile))
+				else
+					flock_convert_turf(tile)
 				sleep(0.5)
 		LAGCHECK(LAG_LOW)
 		radius++
@@ -764,7 +767,7 @@
 			return // our source is gone, stop the process
 
 
-/proc/flock_spiral_conversion(var/turf/T)
+/proc/flock_spiral_conversion(var/turf/T, datum/flock/F)
 	if(!T) return
 	// spiral algorithm adapted from https://stackoverflow.com/questions/398299/looping-in-a-spiral
 	var/ox = T.x
@@ -779,7 +782,10 @@
 	while(isturf(T))
 		if(istype(T, /turf/simulated) && !isfeathertile(T))
 			// do stuff to turf
-			flock_convert_turf(T)
+			if (F)
+				F.claimTurf(flock_convert_turf(T))
+			else
+				flock_convert_turf(T)
 			sleep(0.2 SECONDS)
 		LAGCHECK(LAG_LOW)
 		// figure out where next turf is

--- a/code/obj/flock/structure/relay.dm
+++ b/code/obj/flock/structure/relay.dm
@@ -41,7 +41,7 @@
 	play_sound()
 	flock_speak(null, "RELAY CONSTRUCTED! DEFEND THE RELAY!!", src.flock)
 	SPAWN(1 SECOND)
-		radial_flock_conversion(src, 20)
+		radial_flock_conversion(src, src.flock, 20)
 	SPAWN(10 SECONDS)
 		var/msg = "Overwhelming anomalous power signatures detected on station. This is an existential threat to the station. All personnel must contain this event."
 		msg = radioGarbleText(msg, 7)


### PR DESCRIPTION
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just adds a flock parameter to Flock mass conversion procs, also making the relay use it.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes a bug where stuff converted to Flock by the relay wasn't registering its Flock.

Would be nice to have for the other proc if wanted to be used.