### PR TITLE
Makes pinging turfs a little less weird

### DIFF
--- a/code/datums/flock/flock.dm
+++ b/code/datums/flock/flock.dm
@@ -285,6 +285,8 @@
 		target.render_target = ref(parent)
 		dummy.render_source = target.render_target
 		dummy.add_filter("outline", 1, outline_filter(size=1,color=src.outline_color))
+		if (isturf(target))
+			dummy.add_filter("mask", 2, alpha_mask_filter(icon=dummy.icon, flags=MASK_INVERSE))
 		target.vis_contents += dummy
 
 		play_animation()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[two line PR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes pinging a turf apply an alpha mask to the ping overlay so it doesn't obscure the atoms on the turf. It's limited to turfs because it looks very weird on other things.
![image](https://user-images.githubusercontent.com/20713227/168449635-3f59f64b-4cf5-44cc-8b5c-b01181161b81.png) ![image](https://user-images.githubusercontent.com/20713227/168449647-d11cfafd-cf20-4860-bcf2-0c2a66896472.png)
Pinging the turf vs pinging a thing on the turf.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Looks better
