### PR TITLE
Fixed some flockdrone absorber jank and nerfed paperbin health

### DIFF
--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -473,6 +473,7 @@
 	else
 		boutput(src, "<span class='notice'>You finish converting [I] into resources.</span>")
 	qdel(I)
+	absorber.item = null
 
 
 /mob/living/critter/flock/drone/process_move(keys)

--- a/code/obj/item/paper.dm
+++ b/code/obj/item/paper.dm
@@ -1161,7 +1161,6 @@ as it may become compromised.
 	burn_point = 600
 	burn_output = 800
 	burn_possible = 1
-	health = 100
 
 
 /obj/item/paper_bin/proc/update()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes the flockdrone absorber not clearing its item reference on qdel, leading to it holding a qdeled item and causing jank. Since this was originally a paper bin bug I also stopped paper bins having 100 health because that seems a lot and I haven't learned my lesson about atomization.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
infinitely absorbing paper bins getting stuck in drones is bad