### PR TITLE
Defines flockdrones as restrained while floorrunning

### DIFF
--- a/code/atom.dm
+++ b/code/atom.dm
@@ -584,11 +584,6 @@
 	if (iscarbon(usr) || issilicon(usr))
 		add_fingerprint(usr)
 
-	if (istype(usr, /mob/living/critter/flock/drone))
-		var/mob/living/critter/flock/drone/flockdrone = usr
-		if (flockdrone.floorrunning)
-			return
-
 	if (istype(src,/obj/item/old_grenade/light_gimmick))
 		boutput(usr, "<span class='notice'>You feel your hand reach out and clasp the grenade.</span>")
 		src.Attackhand(usr)

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -67,11 +67,6 @@
 	APPLY_ATOM_PROPERTY(src, PROP_ATOM_FLOCK_THING, src)
 	src.AddComponent(/datum/component/flock_protection, FALSE, FALSE, FALSE, FALSE)
 
-/mob/living/critter/flock/drone/click(atom/target, list/params)
-	if (src.floorrunning)
-		return
-	..()
-
 /mob/living/critter/flock/drone/disposing()
 	if (src.flock)
 		if (controller)
@@ -505,6 +500,7 @@
 	src.set_density(FALSE)
 	src.throws_can_hit_me = FALSE
 	src.set_pulling(null)
+	src.can_throw = FALSE
 	if (src.pulled_by)
 		var/mob/M = src.pulled_by
 		M.set_pulling(null)
@@ -526,6 +522,7 @@
 	src.floorrunning = FALSE
 	src.set_density(TRUE)
 	src.throws_can_hit_me = TRUE
+	src.can_throw = TRUE
 	if (check_lights)
 		if (istype(src.loc, /turf/simulated/floor/feather))
 			var/turf/simulated/floor/feather/floor = src.loc

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -537,6 +537,9 @@
 				wall.off()
 	animate_flock_floorrun_end(src)
 
+/mob/living/critter/flock/drone/restrained()
+	return ..() || src.floorrunning
+
 /mob/living/critter/flock/drone/movement_delay()
 	if(floorrunning)
 		return 0.6


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the cursed pull check in `atom.dm` and replaces it with defining drones as restrained while floorrunning.
This will prevent right click pulling too, if https://github.com/goonstation/goonstation/pull/8726 gets merged.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
f l o c k r e v i e w