### PR TITLE
Lets admins spawn flock rift in space

### DIFF
--- a/code/datums/abilities/flock/flockmind.dm
+++ b/code/datums/abilities/flock/flockmind.dm
@@ -88,11 +88,11 @@
 
 	var/turf/T = get_turf(F)
 
-	if (istype(T, /turf/space/) || istype(T.loc, /area/station/solar) || istype(T.loc, /area/station/mining/magnet))
-		boutput(F, "<span class='alert'>Space and exposed areas are unsuitable for rift placement!</span>")
-		return TRUE
-
 	if (!isadmin(F))
+		if (istype(T, /turf/space/) || istype(T.loc, /area/station/solar) || istype(T.loc, /area/station/mining/magnet))
+			boutput(F, "<span class='alert'>Space and exposed areas are unsuitable for rift placement!</span>")
+			return TRUE
+
 		if(IS_ARRIVALS(T.loc))
 			boutput(F, "<spawn class='alert'>Your rift can't be placed inside arrivals!</span>")
 			return TRUE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves the space/solars/mining magnet check inside a `!isadmin` block so admins can spawn the rift wherever.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
f l o c k r e v i e w