### PR TITLE
Fixes some grab jank

### DIFF
--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -33,7 +33,7 @@
 
 	// antigrab powers
 	var/antigrab_counter = 0
-	var/antigrab_fires_at = 100
+	var/antigrab_fires_at = 3
 
 	var/glow_color = "#26ffe6a2"
 
@@ -399,6 +399,21 @@
 	if (src.dormant)
 		return
 
+	if(length(src.grabbed_by))
+		if (length(src.grabbed_by) == 1 && src.find_type_in_hand(/obj/item/grab/block))
+			src.antigrab_counter = 0
+		else
+			++src.antigrab_counter
+			if(src.antigrab_counter >= src.antigrab_fires_at)
+				playsound(src, "sound/effects/electric_shock.ogg", 40, 1, -3)
+				boutput(src, "<span class='flocksay'><b>\[SYSTEM: Anti-grapple countermeasures deployed.\]</b></span>")
+				for(var/obj/item/grab/G in src.grabbed_by)
+					var/mob/living/L = G.assailant
+					L.shock(src, 5000)
+				src.antigrab_counter = 0
+	else
+		src.antigrab_counter = 0
+
 	var/obj/item/I = absorber.item
 
 	if (!I)
@@ -456,20 +471,6 @@
 
 
 /mob/living/critter/flock/drone/process_move(keys)
-	if(keys && length(src.grabbed_by))
-		if (length(src.grabbed_by) == 1 && src.find_type_in_hand(/obj/item/grab/block))
-			src.antigrab_counter = 0
-		else
-			++src.antigrab_counter
-			if(src.antigrab_counter >= src.antigrab_fires_at)
-				playsound(src, "sound/effects/electric_shock.ogg", 40, 1, -3)
-				boutput(src, "<span class='flocksay'><b>\[SYSTEM: Anti-grapple countermeasures deployed.\]</b></span>")
-				for(var/obj/item/grab/G in src.grabbed_by)
-					var/mob/living/L = G.assailant
-					L.shock(src, 5000)
-				src.antigrab_counter = 0
-	else
-		src.antigrab_counter = 0
 	if(keys & KEY_RUN && src.resources >= 1)
 		if(!src.floorrunning && isfeathertile(src.loc))
 			if (length(src.grabbed_by))

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -386,23 +386,6 @@
 			return 2
 	return ..()
 
-///Runs the drone's inbuilt anti-grab measures, shocking the grabber after a while
-/mob/living/critter/flock/drone/proc/do_antigrab()
-	//if we're blocking that means we're not grabbed
-	if (!length(src.grabbed_by) || src.find_type_in_hand(/obj/item/grab/block))
-		src.antigrab_counter = 0
-		return
-
-	src.antigrab_counter++
-	if (src.antigrab_counter >= src.antigrab_fires_at)
-		playsound(src, "sound/effects/electric_shock.ogg", 40, 1, -3)
-		boutput(src, "<span class='flocksay'><b>\[SYSTEM: Anti-grapple countermeasures deployed.\]</b></span>")
-		for(var/obj/item/grab/G in src.grabbed_by)
-			var/mob/living/L = G.assailant
-			L.shock(src, 5000)
-			qdel(G) //in case they don't fall over from our shock
-		src.antigrab_counter = 0
-
 /mob/living/critter/flock/drone/Life(datum/controller/process/mobs/parent)
 	if (..(parent))
 		return TRUE
@@ -416,7 +399,19 @@
 	if (src.dormant)
 		return
 
-	src.do_antigrab()
+	//if we're blocking that means we're not grabbed
+	if (!length(src.grabbed_by) || src.find_type_in_hand(/obj/item/grab/block))
+		src.antigrab_counter = 0
+	else
+		src.antigrab_counter++
+		if (src.antigrab_counter >= src.antigrab_fires_at)
+			playsound(src, "sound/effects/electric_shock.ogg", 40, 1, -3)
+			boutput(src, "<span class='flocksay'><b>\[SYSTEM: Anti-grapple countermeasures deployed.\]</b></span>")
+			for(var/obj/item/grab/G in src.grabbed_by)
+				var/mob/living/L = G.assailant
+				L.shock(src, 5000)
+				qdel(G) //in case they don't fall over from our shock
+			src.antigrab_counter = 0
 
 	var/obj/item/I = absorber.item
 

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -393,8 +393,8 @@
 		src.antigrab_counter = 0
 		return
 
-	antigrab_counter++
-	if (antigrab_counter >= src.antigrab_fires_at)
+	src.antigrab_counter++
+	if (src.antigrab_counter >= src.antigrab_fires_at)
 		playsound(src, "sound/effects/electric_shock.ogg", 40, 1, -3)
 		boutput(src, "<span class='flocksay'><b>\[SYSTEM: Anti-grapple countermeasures deployed.\]</b></span>")
 		for(var/obj/item/grab/G in src.grabbed_by)

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -388,8 +388,8 @@
 
 ///Runs the drone's inbuilt anti-grab measures, shocking the grabber after a while
 /mob/living/critter/flock/drone/proc/do_antigrab()
-	//if the only grab is a block then ignore it
-	if (!length(src.grabbed_by) || (length(src.grabbed_by) == 1 && src.find_type_in_hand(/obj/item/grab/block)))
+	//if we're blocking that means we're not grabbed
+	if (!length(src.grabbed_by) || src.find_type_in_hand(/obj/item/grab/block))
 		src.antigrab_counter = 0
 		return
 
@@ -398,8 +398,6 @@
 		playsound(src, "sound/effects/electric_shock.ogg", 40, 1, -3)
 		boutput(src, "<span class='flocksay'><b>\[SYSTEM: Anti-grapple countermeasures deployed.\]</b></span>")
 		for(var/obj/item/grab/G in src.grabbed_by)
-			if (istype(G, /obj/item/grab/block)) //do not shock ourselves
-				continue
 			var/mob/living/L = G.assailant
 			L.shock(src, 5000)
 			qdel(G) //in case they don't fall over from our shock

--- a/code/turf/turf_flock.dm
+++ b/code/turf/turf_flock.dm
@@ -49,6 +49,10 @@
 	// do not call parent, this is not an ordinary floor
 	if(!C || !user)
 		return
+	if (istype(C, /obj/item/grab/))
+		var/obj/item/grab/G = C
+		grab_smash(G, user)
+		return
 	if(ispryingtool(C) && src.broken)
 		playsound(src, "sound/items/Crowbar.ogg", 80, 1)
 		src.break_tile_to_plating()

--- a/code/turf/turf_flock.dm
+++ b/code/turf/turf_flock.dm
@@ -49,9 +49,8 @@
 	// do not call parent, this is not an ordinary floor
 	if(!C || !user)
 		return
-	if (istype(C, /obj/item/grab/))
-		var/obj/item/grab/G = C
-		grab_smash(G, user)
+	if (istype(C, /obj/item/grab))
+		grab_smash(C, user)
 		return
 	if(ispryingtool(C) && src.broken)
 		playsound(src, "sound/items/Crowbar.ogg", 80, 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The flockdrone antigrab system wasn't actually working if the drone was AI controlled, since it was in client called movement code. I've moved it into the life loop, so now it just activates after a certain number of life loop calls.
Also fixed pins not working on flock tiles because it's related shut up.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
no grabbing drones >:(