### PR TITLE
Revert nerfs to flockdrone absorption

### DIFF
--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -26,7 +26,8 @@
 	butcherable = TRUE
 
 	var/health_absorb_rate = 2 // how much item health is removed per tick when absorbing
-	var/resources_per_health = 2 // how much resources we get per item health
+	var/resources_per_health = 3 // how much resources we get per item health
+	var/absorb_completion = 5 // how much resources we get after the item is totally eaten
 
 	var/floorrunning = FALSE
 	var/can_floorrun = TRUE
@@ -460,6 +461,7 @@
 			boutput(src, "<span class='notice'>You assimilate [F]'s resource cache, adding <span class='bold'>[F.resources]</span> resource[F.resources > 1 ? "s" : null] to your own.</span>")
 	else
 		boutput(src, "<span class='notice'>You finish converting [I] into resources.</span>")
+	src.resources += absorb_completion
 	qdel(I)
 	absorber.item = null
 

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -26,8 +26,7 @@
 	butcherable = TRUE
 
 	var/health_absorb_rate = 2 // how much item health is removed per tick when absorbing
-	var/resources_per_health = 3 // how much resources we get per item health
-	var/absorb_completion = 5 // how much resources we get after the item is totally eaten
+	var/resources_per_health = 4 // how much resources we get per item health
 
 	var/floorrunning = FALSE
 	var/can_floorrun = TRUE
@@ -461,7 +460,6 @@
 			boutput(src, "<span class='notice'>You assimilate [F]'s resource cache, adding <span class='bold'>[F.resources]</span> resource[F.resources > 1 ? "s" : null] to your own.</span>")
 	else
 		boutput(src, "<span class='notice'>You finish converting [I] into resources.</span>")
-	src.resources += absorb_completion
 	qdel(I)
 	absorber.item = null
 

--- a/code/obj/flock/structure/egg.dm
+++ b/code/obj/flock/structure/egg.dm
@@ -21,11 +21,14 @@
 	var/elapsed = getTimeInSecondsSinceTime(src.time_started)
 	if(elapsed >= build_time)
 		src.visible_message("<span class='notice'>[src] breaks open!</span>")
-		new /mob/living/critter/flock/drone(get_turf(src), src.flock)
+		src.spawn_contents()
 		qdel(src)
 	else
 		var/severity = round(((build_time - elapsed)/build_time) * 5)
 		animate_shake(src, severity, severity)
+
+/obj/flock_structure/egg/proc/spawn_contents()
+	new /mob/living/critter/flock/drone(get_turf(src), src.flock)
 
 /obj/flock_structure/egg/throw_impact(atom/A, datum/thrown_thing/thr)
 	var/turf/T = get_turf(A)
@@ -35,3 +38,10 @@
 		make_cleanable( /obj/decal/cleanable/flockdrone_debris/fluid,T)
 		decal_made = TRUE
 	..()
+
+/obj/flock_structure/egg/bit
+	flock_id = "Secondary Second-Stage Assembler"
+
+/obj/flock_structure/egg/bit/spawn_contents()
+	for (var/i in 1 to 3)
+		new /mob/living/critter/flock/bit(get_turf(src), src.flock)

--- a/code/obj/flock/structure/rift.dm
+++ b/code/obj/flock/structure/rift.dm
@@ -27,6 +27,8 @@
 		for(var/i in 1 to 4)
 			var/obj/flock_structure/egg/e = new(src.contents, src.flock)
 			eject += e
+		var/obj/flock_structure/egg/bit/bitegg = new(src.contents, src.flock)
+		eject += bitegg
 		var/list/candidate_turfs = list()
 		for(var/turf/simulated/floor/S in orange(src, 4))
 			candidate_turfs += S


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Partially reverts the nerfs to flockdrone resource absorption from #270.
Flockdrones now gain 4 resources per health absorbed.
The flock rift now comes with an extra egg containing 3 flockbits.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Flockdrones were replicating at an extremely slow rate, meaning they were basically unable to sustain any real losses incurred. 
The nerf cut the rate at which flock could gain resources by around 4 times, this caused flock to not really work anymore.