### PR TITLE
Allow flock to work as a random event antag

### DIFF
--- a/code/datums/flock/flock.dm
+++ b/code/datums/flock/flock.dm
@@ -4,6 +4,8 @@
 
 /// associative list of flock names to their flock
 /var/list/flocks = list()
+/// Has a flock relay been unleashed yet this round
+var/signal_unleashed = FALSE
 
 /// manages and holds information for a flock
 /datum/flock

--- a/code/datums/flock/flock.dm
+++ b/code/datums/flock/flock.dm
@@ -5,7 +5,7 @@
 /// associative list of flock names to their flock
 /var/list/flocks = list()
 /// Has a flock relay been unleashed yet this round
-var/signal_unleashed = FALSE
+var/flock_signal_unleashed = FALSE
 
 /// manages and holds information for a flock
 /datum/flock

--- a/code/datums/gamemodes/flock.dm
+++ b/code/datums/gamemodes/flock.dm
@@ -35,7 +35,7 @@
 	return TRUE
 
 /datum/game_mode/flock/victory_msg()
-	if (signal_unleashed)
+	if (flock_signal_unleashed)
 		return "<b style='font-size:20px'>Flock victory!</b><br>The Flock managed to construct a relay and transmit The Signal. One step closer to its mysterious goals."
 	else
 		var/living_flockmind = FALSE

--- a/code/datums/gamemodes/flock.dm
+++ b/code/datums/gamemodes/flock.dm
@@ -7,8 +7,6 @@
 
 	//NOTE: if you need to track something, put it here
 	var/list/datum/mind/flockminds = list()
-	/// Has a relay been unleashed yet this round
-	var/signal_unleashed = FALSE
 
 /datum/game_mode/flock/announce()
 	boutput(world, "<B>The current game mode is - Flock!</B>")
@@ -37,7 +35,7 @@
 	return TRUE
 
 /datum/game_mode/flock/victory_msg()
-	if (src.signal_unleashed)
+	if (signal_unleashed)
 		return "<b style='font-size:20px'>Flock victory!</b><br>The Flock managed to construct a relay and transmit The Signal. One step closer to its mysterious goals."
 	else
 		var/living_flockmind = FALSE

--- a/code/datums/objective.dm
+++ b/code/datums/objective.dm
@@ -814,8 +814,7 @@ proc/create_fluff(datum/mind/target)
 	explanation_text = "Construct the relay and transmit The Signal."
 
 	check_completion()
-		var/datum/game_mode/flock/flockmode = ticker.mode
-		return istype(flockmode) && flockmode.signal_unleashed
+		return signal_unleashed
 
 
 /datum/objective/specialist/wraith

--- a/code/datums/objective.dm
+++ b/code/datums/objective.dm
@@ -814,7 +814,7 @@ proc/create_fluff(datum/mind/target)
 	explanation_text = "Construct the relay and transmit The Signal."
 
 	check_completion()
-		return signal_unleashed
+		return flock_signal_unleashed
 
 
 /datum/objective/specialist/wraith

--- a/code/modules/events/antag_ghost_respawn.dm
+++ b/code/modules/events/antag_ghost_respawn.dm
@@ -22,7 +22,7 @@
 			message_admins("Setup of previous Antagonist Spawn hasn't finished yet, aborting.")
 			return
 
-		var/type = input(usr, "Select antagonist type.", "Antagonists", "Blob") as null|anything in list("Blob", "Blob (AI)", "Hunter", "Werewolf", "Wizard", "Wraith", "Wrestler", "Wrestler_Doodle", "Vampire", "Changeling", "Headspider", "Arcfiend")
+		var/type = input(usr, "Select antagonist type.", "Antagonists", "Blob") as null|anything in list("Blob", "Blob (AI)", "Hunter", "Werewolf", "Wizard", "Wraith", "Wrestler", "Wrestler_Doodle", "Vampire", "Changeling", "Headspider", "Arcfiend", "Flockmind")
 		if (!type)
 			return
 		else
@@ -198,7 +198,7 @@
 				if (F && istype(F))
 					M3 = F
 					role = ROLE_FLOCKMIND
-					//objective_path = /datum/objective_set/blob
+					objective_path = /datum/objective/specialist/flock
 					send_to = 3
 				else
 					failed = 1

--- a/code/obj/flock/structure/relay.dm
+++ b/code/obj/flock/structure/relay.dm
@@ -112,9 +112,7 @@
 			flockdronegibs(locate(location.x + x, location.y + y, location.z))
 	explosion_new(src, location, 2000)
 	gib(location)
-	var/datum/game_mode/flock/gamemode = ticker.mode
-	if(istype(gamemode))
-		gamemode.signal_unleashed = TRUE
+	signal_unleashed = TRUE
 	sleep(2 SECONDS) //allow them to hear the explosion before their headsets scream and die
 	destroy_radios()
 

--- a/code/obj/flock/structure/relay.dm
+++ b/code/obj/flock/structure/relay.dm
@@ -112,7 +112,7 @@
 			flockdronegibs(locate(location.x + x, location.y + y, location.z))
 	explosion_new(src, location, 2000)
 	gib(location)
-	signal_unleashed = TRUE
+	flock_signal_unleashed = TRUE
 	sleep(2 SECONDS) //allow them to hear the explosion before their headsets scream and die
 	destroy_radios()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Enables the flockmind random event antag spawn (for admin spawns only) and changes some stuff to make it work.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Flockmind admin spawns are a good way of testing flock without devoting a whole round to the (currently probably very imbalanced) flock gamemode