### PR TITLE
Added attack feedback to flock structures

### DIFF
--- a/code/obj/flock/cage.dm
+++ b/code/obj/flock/cage.dm
@@ -12,6 +12,7 @@
 	health_max = 30
 	alpha = 192
 	anchored = FALSE
+	hitTwitch = FALSE
 	var/atom/occupant = null
 	var/obj/target = null
 	var/eating_occupant = FALSE

--- a/code/obj/flock/structure/flock_structure_parent.dm
+++ b/code/obj/flock/structure/flock_structure_parent.dm
@@ -202,7 +202,12 @@ ABSTRACT_TYPE(/obj/flock_structure)
 		damtype = "fire"
 
 	takeDamage(damtype, W.force)
-	playsound(src.loc, "sound/impact_sounds/Crystal_Hit_1.ogg", 50, 1)
+	hit_twitch(src)
+	if (W.force < 5)
+		playsound(src.loc, "sound/impact_sounds/Crystal_Hit_1.ogg", 50, 1)
+	else
+		playsound(src.loc, "sound/impact_sounds/Glass_Shards_Hit_1.ogg", 50, 1)
+
 
 /obj/flock_structure/proc/report_attack()
 	if (!ON_COOLDOWN(src, "attack_alert", 10 SECONDS))

--- a/code/obj/flock/structure/flock_structure_parent.dm
+++ b/code/obj/flock/structure/flock_structure_parent.dm
@@ -17,6 +17,8 @@ ABSTRACT_TYPE(/obj/flock_structure)
 	var/health = 30
 	var/health_max = 30
 	var/bruteVuln = 1.2
+	///Should it twitch on being hit?
+	var/hitTwitch = TRUE
 
 	var/fireVuln = 0.2
 	var/datum/flock/flock = null
@@ -202,7 +204,8 @@ ABSTRACT_TYPE(/obj/flock_structure)
 		damtype = "fire"
 
 	takeDamage(damtype, W.force)
-	hit_twitch(src)
+	if (src.hitTwitch)
+		hit_twitch(src)
 	if (W.force < 5)
 		playsound(src.loc, "sound/impact_sounds/Crystal_Hit_1.ogg", 50, 1)
 	else

--- a/code/obj/flock/structure/relay.dm
+++ b/code/obj/flock/structure/relay.dm
@@ -16,6 +16,7 @@
 	pixel_y = -64
 	bound_x = -64
 	bound_y = -64
+	hitTwitch = FALSE
 	layer = EFFECTS_LAYER_BASE //big spooky thing needs to render over everything
 	plane = PLANE_NOSHADOW_ABOVE
 	var/last_time_sound_played_in_seconds = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a shake animation when flock structures are hit with something and makes them use a crunchy glass sound when they are attacked with something heavy.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Attack feedback good, makes it obvious that this is a thing you can and should destroy.